### PR TITLE
feat(constructorType): Add constructor type descriptor

### DIFF
--- a/config/karma/karma.config.transformer.playground.build.js
+++ b/config/karma/karma.config.transformer.playground.build.js
@@ -1,0 +1,7 @@
+const karmaBaseConfig = require('./karma.config.base');
+
+module.exports = function(config) {
+    const karmaConfig = karmaBaseConfig(config, '../../test/playground/**/*.test.js');
+
+    config.set(karmaConfig);
+};

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -41,7 +41,7 @@ mock.name // ""
 ```
 ## Classes
 ```ts
-interface Person {
+class Person {
     private _id: string;
     name: string 
 }
@@ -211,4 +211,16 @@ interface Interface {
 
 const mock = createMock<Interface>();
 mock // { intersection: { a: "", b: 0 } }
+```
+
+## ConstructorType
+
+```ts
+interface Test {
+    a: string;
+}
+const mockType = createMock<new () => Test>();
+const mock = new mockType();
+
+mock = // { a: "" }
 ```

--- a/docs/NOT_SUPPORTED.md
+++ b/docs/NOT_SUPPORTED.md
@@ -33,18 +33,6 @@ const mock = createMock<Test>();
 mock.conditional // should be string. It will be null
 ```
 
-## ConstructorType
-
-This scenario needs to be investigated
-
-```ts
-interface Test {
-    toConstructor(): new (): Test
-}
-const mock = createMock<Test>();
-mock.toConstructor() // will be null
-```
-
 ## TypeQuery
 [bug](https://github.com/uittorio/ts-auto-mock/issues/91)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:unit": "karma start config/karma/karma.config.unit.js",
     "test:transformer": "karma start config/karma/karma.config.transformer.js",
     "test:playground": "karma start config/karma/karma.config.transformer.playground.js",
+    "test:playground:build": "karma start config/karma/karma.config.transformer.playground.build.js",
     "test:framework:context": "karma start config/karma/karma.config.framework.context.js",
     "test:frameworkDeprecated": "karma start config/karma/karma.config.framework.deprecated.js",
     "test:framework": "karma start config/karma/karma.config.framework.js DISABLECACHE=true",

--- a/src/transformer/descriptor/constructor/constructorType.ts
+++ b/src/transformer/descriptor/constructor/constructorType.ts
@@ -1,0 +1,8 @@
+import * as ts from 'typescript';
+import { TypescriptCreator } from '../../helper/creator';
+import { Scope } from '../../scope/scope';
+import { GetDescriptor } from '../descriptor';
+
+export function GetConstructorTypeDescriptor(node: ts.ConstructorTypeNode, scope: Scope): ts.Expression {
+  return TypescriptCreator.createFunctionExpressionReturn(GetDescriptor(node.type, scope));
+}

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -7,6 +7,7 @@ import { GetBooleanDescriptor } from './boolean/boolean';
 import { GetBooleanFalseDescriptor } from './boolean/booleanFalse';
 import { GetBooleanTrueDescriptor } from './boolean/booleanTrue';
 import { GetClassDeclarationDescriptor } from './class/classDeclaration';
+import { GetConstructorTypeDescriptor } from './constructor/constructorType';
 import { GetEnumDeclarationDescriptor } from './enum/enumDeclaration';
 import { GetExpressionWithTypeArgumentsDescriptor } from './expression/expressionWithTypeArguments';
 import { GetIdentifierDescriptor } from './identifier/identifier';
@@ -74,6 +75,8 @@ export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
         case ts.SyntaxKind.ArrowFunction:
         case ts.SyntaxKind.FunctionExpression:
             return GetFunctionAssignmentDescriptor(node as ts.ArrowFunction, scope);
+        case ts.SyntaxKind.ConstructorType:
+            return GetConstructorTypeDescriptor(node as ts.ConstructorTypeNode, scope);
         case ts.SyntaxKind.UnionType:
             return GetUnionDescriptor(node as ts.UnionTypeNode, scope);
         case ts.SyntaxKind.IntersectionType:

--- a/test/playground/playground.test.ts
+++ b/test/playground/playground.test.ts
@@ -9,11 +9,16 @@ import { createMock } from 'ts-auto-mock';
  */
 
 it('should work', () => {
+    interface Newable {
+        b: string;
+    }
+    
     interface Interface {
-        a: string;
+        a: new () => Newable;
+        b: Newable;
     }
 
     const properties: Interface = createMock<Interface>();
 
-    expect(properties.a).toEqual('');
+    expect(new (properties.a)().b).toEqual('');
 });

--- a/test/transformer/descriptor/constructor/constructorType.test.ts
+++ b/test/transformer/descriptor/constructor/constructorType.test.ts
@@ -36,7 +36,7 @@ describe('constructorType', () => {
     });
   });
   
-  describe('of an class', () => {
+  describe('of a class', () => {
     it('should create a concrete newable type of the class', () => {
       class Test {
         a: string;

--- a/test/transformer/descriptor/constructor/constructorType.test.ts
+++ b/test/transformer/descriptor/constructor/constructorType.test.ts
@@ -1,8 +1,8 @@
 import { createMock } from 'ts-auto-mock';
 
 describe('constructorType', () => {
-  describe('of an interface', function() {
-    it('should create a concrete newable type of the interface', function() {
+  describe('of an interface', () => {
+    it('should create a concrete newable type of the interface', () => {
       interface Test {
         a: string;
         b: number;
@@ -15,7 +15,7 @@ describe('constructorType', () => {
       expect(mockInstance.b).toEqual(0);
     });
     
-    it('should not create a singleton newable type of the interface', function() {
+    it('should not create a singleton newable type of the interface', () => {
       interface Test {
         a: string;
         b: number;
@@ -36,8 +36,8 @@ describe('constructorType', () => {
     });
   });
   
-  describe('of an class', function() {
-    it('should create a concrete newable type of the class', function() {
+  describe('of an class', () => {
+    it('should create a concrete newable type of the class', () => {
       class Test {
         a: string;
         b: number;
@@ -51,8 +51,8 @@ describe('constructorType', () => {
     });
   });
 
-  describe('in a property', function() {
-    it('should create a concrete newable type in the property', function() {
+  describe('in a property', () => {
+    it('should create a concrete newable type in the property', () => {
       interface Test {
         a: string;
         b: number;
@@ -67,8 +67,8 @@ describe('constructorType', () => {
     });
   });
 
-  describe('in a method', function() {
-    it('should create a concrete newable type as a method returned value', function() {
+  describe('in a method', () => {
+    it('should create a concrete newable type as a method returned value', () => {
       interface Test {
         a: string;
         b: number;
@@ -83,8 +83,8 @@ describe('constructorType', () => {
     });
   });
 
-  describe('from a type', function() {
-    it('should create a concrete newable type', function() {
+  describe('from a type', () => {
+    it('should create a concrete newable type', () => {
       interface Test {
         a: string;
         b: number;

--- a/test/transformer/descriptor/constructor/constructorType.test.ts
+++ b/test/transformer/descriptor/constructor/constructorType.test.ts
@@ -1,0 +1,85 @@
+import { createMock } from 'ts-auto-mock';
+
+describe('constructorType', () => {
+  describe('of an interface', function() {
+    it('should create a concrete newable type of the interface', function() {
+      interface Test {
+        a: string;
+        b: number;
+      }
+
+      const mockConstructorType: new () => Test = createMock<new () => Test>();
+      const mockInstance: Test = new mockConstructorType();
+
+      expect(mockInstance.a).toEqual('');
+      expect(mockInstance.b).toEqual(0);
+    });
+    
+    it('should not create a singleton newable type of the interface', function() {
+      interface Test {
+        a: string;
+        b: number;
+      }
+
+      const mockConstructorType: new () => Test = createMock<new () => Test>();
+      const mockInstance1: Test = new mockConstructorType();
+      const mockInstance2: Test = new mockConstructorType();
+      const mockInstance3: Test = new mockConstructorType();
+      
+      mockInstance1.a = 'test1';
+      mockInstance2.a = 'test2';
+      mockInstance3.a = 'test3';
+
+      expect(mockInstance1.a).toEqual('test1');
+      expect(mockInstance2.a).toEqual('test2');
+      expect(mockInstance3.a).toEqual('test3');
+    });
+  });
+  
+  describe('of an class', function() {
+    it('should create a concrete newable type of the class', function() {
+      class Test {
+        a: string;
+        b: number;
+      }
+
+      const mockConstructorType: new () => Test = createMock<new () => Test>();
+      const mockInstance: Test = new mockConstructorType();
+
+      expect(mockInstance.a).toEqual('');
+      expect(mockInstance.b).toEqual(0);
+    });
+  });
+
+  describe('in a property', function() {
+    it('should create a concrete newable type in the property', function() {
+      interface Test {
+        a: string;
+        b: number;
+        c: new () => Test;
+      }
+
+      const mock: Test = createMock<Test>();
+      const instance: Test = new mock.c();
+
+      expect(instance.a).toEqual('');
+      expect(instance.b).toEqual(0);
+    });
+  });
+
+  describe('in a method', function() {
+    it('should create a concrete newable type as a method returned value', function() {
+      interface Test {
+        a: string;
+        b: number;
+        c(): new () => Test;
+      }
+
+      const mock: Test = createMock<Test>();
+      const instance: Test = new (mock.c())();
+
+      expect(instance.a).toEqual('');
+      expect(instance.b).toEqual(0);
+    });
+  });
+});

--- a/test/transformer/descriptor/constructor/constructorType.test.ts
+++ b/test/transformer/descriptor/constructor/constructorType.test.ts
@@ -82,4 +82,21 @@ describe('constructorType', () => {
       expect(instance.b).toEqual(0);
     });
   });
+
+  describe('from a type', function() {
+    it('should create a concrete newable type', function() {
+      interface Test {
+        a: string;
+        b: number;
+      }
+
+      type TestType = new () => Test;
+
+      const mockType: TestType = createMock<TestType>();
+      const instance: Test = new mockType();
+
+      expect(instance.a).toEqual('');
+      expect(instance.b).toEqual(0);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds constructor type to the handled types.
Since a function works for most (if not all) cases my solution is to use it:

```ts
interface Test {
  recursive: Test;
  recursiveConstructor: new () => Test;
}
const mock = createMock<Test>();
```

will generate something like this

```js
Object.defineProperties(__tsAutoMockObjectReturnValue, {
  recursive: {
    get: function () {
      return _srecursive || (_srecursive = import_Repository.ɵRepository.instance.getFactory("create__test__mock_1")([]));
    }, set: function (_recursive) {
      _srecursive = _recursive;
    }, enumerable: true
  },
  recursiveConstructor: {
    get: function () {
      return _srecursiveConstructor || (_srecursiveConstructor = function () {
        return import_Repository.ɵRepository.instance.getFactory("create__test__mock_1")([]);
      });
    }, set: function (_recursiveConstructor) {
      _srecursiveConstructor = _recursiveConstructor;
    }, enumerable: true
  }
});
```

I've also updated the documentation (moving the constructor type from unsupported to supported), fixed a piece of documentation, and added a karma configuration+npm script to be able to run the playground js without compilation (this will allow creating poc of the solution in js to see if it works before creating the ast).

Let me know if you have any concern