### PR TITLE
feat(constructSignature): add construct signature

### DIFF
--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -39,6 +39,28 @@ mock() // 0
 mock.name // ""
 
 ```
+## Interfaces with construct signatures
+For overload constructors it will use the first one
+```ts
+interface PersonWithHat {
+    hatSize: number;
+}
+
+interface PersonWithoutHat {
+    shirtSize: number;
+}
+
+interface Person {
+    new (hatSize: number): PersonWithHat
+    new (): PersonWithoutHat
+    name: string
+}
+
+const mock = createMock<Person>();
+new mock() // { hatSize: 0 }
+mock.name // ""
+
+```
 ## Classes
 ```ts
 class Person {

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -71,8 +71,9 @@ export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
         case ts.SyntaxKind.FunctionType:
             return GetFunctionTypeDescriptor(node as ts.FunctionTypeNode, scope);
         case ts.SyntaxKind.ConstructSignature:
+            return GetFunctionTypeDescriptor(node as ts.ConstructSignatureDeclaration, scope);
         case ts.SyntaxKind.CallSignature:
-            return GetFunctionTypeDescriptor(node as ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration, scope);
+            return GetFunctionTypeDescriptor(node as ts.CallSignatureDeclaration, scope);
         case ts.SyntaxKind.ArrowFunction:
         case ts.SyntaxKind.FunctionExpression:
             return GetFunctionAssignmentDescriptor(node as ts.ArrowFunction, scope);

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -70,8 +70,9 @@ export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
             return GetMethodDeclarationDescriptor(node as ts.MethodDeclaration, scope);
         case ts.SyntaxKind.FunctionType:
             return GetFunctionTypeDescriptor(node as ts.FunctionTypeNode, scope);
+        case ts.SyntaxKind.ConstructSignature:
         case ts.SyntaxKind.CallSignature:
-            return GetFunctionTypeDescriptor(node as ts.CallSignatureDeclaration, scope);
+            return GetFunctionTypeDescriptor(node as ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration, scope);
         case ts.SyntaxKind.ArrowFunction:
         case ts.SyntaxKind.FunctionExpression:
             return GetFunctionAssignmentDescriptor(node as ts.ArrowFunction, scope);

--- a/src/transformer/descriptor/method/functionType.ts
+++ b/src/transformer/descriptor/method/functionType.ts
@@ -4,7 +4,7 @@ import { GetDescriptor } from '../descriptor';
 import { PropertySignatureCache } from '../property/cache';
 import { GetMethodDescriptor } from './method';
 
-export function GetFunctionTypeDescriptor(node: ts.FunctionTypeNode | ts.CallSignatureDeclaration, scope: Scope): ts.Expression {
+export function GetFunctionTypeDescriptor(node: ts.FunctionTypeNode | ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration, scope: Scope): ts.Expression {
     const property: ts.PropertyName = PropertySignatureCache.instance.get();
 
     const returnValue: ts.Expression = GetDescriptor(node.type, scope);

--- a/src/transformer/descriptor/properties/properties.ts
+++ b/src/transformer/descriptor/properties/properties.ts
@@ -9,7 +9,7 @@ export function GetProperties(node: ts.Node, scope: Scope): ts.Expression {
     const type: ts.Type = typeChecker.getTypeAtLocation(node);
     const symbols: ts.Symbol[] = typeChecker.getPropertiesOfType(type);
 
-    let signatures: Array<ts.Signature> = [];
+    const signatures: Array<ts.Signature> = [];
     Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Call));
     Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Construct));
 

--- a/src/transformer/descriptor/properties/properties.ts
+++ b/src/transformer/descriptor/properties/properties.ts
@@ -9,7 +9,6 @@ export function GetProperties(node: ts.Node, scope: Scope): ts.Expression {
     const type: ts.Type = typeChecker.getTypeAtLocation(node);
     const symbols: ts.Symbol[] = typeChecker.getPropertiesOfType(type);
 
-    // const signatures: ReadonlyArray<ts.Signature> = typeChecker.getSignaturesOfType(type, SignatureKind.Call);
     let signatures: Array<ts.Signature> = [];
     Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Call));
     Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Construct));

--- a/src/transformer/descriptor/properties/properties.ts
+++ b/src/transformer/descriptor/properties/properties.ts
@@ -9,7 +9,10 @@ export function GetProperties(node: ts.Node, scope: Scope): ts.Expression {
     const type: ts.Type = typeChecker.getTypeAtLocation(node);
     const symbols: ts.Symbol[] = typeChecker.getPropertiesOfType(type);
 
-    const signatures: ReadonlyArray<ts.Signature> = typeChecker.getSignaturesOfType(type, SignatureKind.Call);
+    // const signatures: ReadonlyArray<ts.Signature> = typeChecker.getSignaturesOfType(type, SignatureKind.Call);
+    let signatures: Array<ts.Signature> = [];
+    Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Call));
+    Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Construct));
 
     return GetMockPropertiesFromSymbol(symbols, signatures, scope);
 }

--- a/test/transformer/descriptor/methods/methods.test.ts
+++ b/test/transformer/descriptor/methods/methods.test.ts
@@ -88,6 +88,68 @@ describe('for methods', () => {
         });
     });
 
+    describe('for interface construct signature', () => {
+        interface InterfaceWithConstructSignature {
+            new (a: number): { a: number };
+            b: string;
+        }
+
+        interface InterfaceWithConstructSignatureReturn {
+            new (a: number): InterfaceWithConstructSignature;
+            b: string;
+        }
+
+        interface InterfaceWithConstructSignatureOverload {
+            new (a: number): { a: number };
+            new (b: string): { b: string };
+            new (): { c: Date };
+        }
+
+        it('should set the constructor and properties', () => {
+            const properties: InterfaceWithConstructSignature = createMock<InterfaceWithConstructSignature>();
+            expect(new properties(2).a).toBe(0);
+            expect(properties.b).toBe('');
+        });
+
+        it('should set the constructor with return value constructor', () => {
+            const properties: InterfaceWithConstructSignatureReturn = createMock<InterfaceWithConstructSignatureReturn>();
+            expect(new (new properties(2))(2).a).toBe(0);
+            expect(new properties(2).b).toBe('');
+            expect(properties.b).toBe('');
+        });
+
+        it('should use the first overload if any', () => {
+            const properties: InterfaceWithConstructSignatureOverload = createMock<InterfaceWithConstructSignatureOverload>();
+            //tslint:disable-next-line
+            expect((new properties() as any).a).toBe(0);
+        });
+    });
+
+    describe('for interface construct signature', () => {
+        interface InterfaceWithCallSignature {
+            new (a: number): { a: number };
+            b: string;
+        }
+
+        interface InterfaceWithCallSignatureReturn {
+            new (a: number): InterfaceWithCallSignature;
+            b: string;
+        }
+
+        it('should set the constructor and properties', () => {
+            const properties: InterfaceWithCallSignature = createMock<InterfaceWithCallSignature>();
+            expect(new properties(2).a).toBe(0);
+            expect(properties.b).toBe('');
+        });
+
+        it('should set the constructor with return value constructor', () => {
+            const properties: InterfaceWithCallSignatureReturn = createMock<InterfaceWithCallSignatureReturn>();
+            expect(new (new properties(2))(2).a).toBe(0);
+            expect(new properties(2).b).toBe('');
+            expect(properties.b).toBe('');
+        });
+    });
+
     describe('for declaration', () => {
         class MyClass {
             public method(): number {


### PR DESCRIPTION
I'm going to treat construct signature in the same way as call signature.

Something doesn't work perfectly but I think it's a non-problem:

```ts
interface Test {
  new (): string;
}
```

is an accepted signature but my implementation can handle only constructions of object-like values.

Let me know if this concerns you