### PR TITLE
 feat(typeQuery): add support to typeQuery (typeof) to fix #91

### DIFF
--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -246,3 +246,28 @@ const mock = new mockType();
 
 mock = // { a: "" }
 ```
+
+## TypeQuery
+```ts
+enum AnEnum {
+    a,
+    b = 'something',
+}
+
+const mock = createMock<typeof AnEnum>();
+mock.a // 0
+mock.b // 'something'
+mock[0] // 'a'
+
+class AClass {
+    a: string
+}
+
+const mockClass = createMock<typeof AClass>();
+new mockClass().a // ''
+
+function AFunction(): number;
+
+const mockFunction = createMock<typeof AFunction>();
+mockFunction() // 0
+```

--- a/docs/NOT_SUPPORTED.md
+++ b/docs/NOT_SUPPORTED.md
@@ -32,22 +32,3 @@ const mock = createMock<Test>();
 
 mock.conditional // should be string. It will be null
 ```
-
-## TypeQuery
-[bug](https://github.com/uittorio/ts-auto-mock/issues/91)
-
-This scenario needs to be investigated
-```ts
-enum AnEnum {
-    a,
-    b,
-}
-interface Test {
-    type: typeof AnEnum
-}
-
-const mock = createMock<Test>();
-mock.type // will be null
-```
-
-

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -1,7 +1,11 @@
 import * as ts from 'typescript';
+import { printer } from '../../printer';
+import { TypescriptCreator } from '../helper/creator';
 import { TransformerLogger } from '../logger/transformerLogger';
-import { GetMockFactoryCallForThis } from '../mockFactoryCall/mockFactoryCall';
+import { MockDefiner } from '../mockDefiner/mockDefiner';
+import { GetMockFactoryCall, GetMockFactoryCallForThis } from '../mockFactoryCall/mockFactoryCall';
 import { Scope } from '../scope/scope';
+import { TypeChecker } from '../typeChecker/typeChecker';
 import { GetArrayDescriptor } from './array/array';
 import { GetBooleanDescriptor } from './boolean/boolean';
 import { GetBooleanFalseDescriptor } from './boolean/booleanFalse';
@@ -10,6 +14,7 @@ import { GetClassDeclarationDescriptor } from './class/classDeclaration';
 import { GetConstructorTypeDescriptor } from './constructor/constructorType';
 import { GetEnumDeclarationDescriptor } from './enum/enumDeclaration';
 import { GetExpressionWithTypeArgumentsDescriptor } from './expression/expressionWithTypeArguments';
+import { TypescriptHelper } from './helper/helper';
 import { GetIdentifierDescriptor } from './identifier/identifier';
 import { GetImportDescriptor } from './import/import';
 import { GetImportEqualsDescriptor } from './import/importEquals';
@@ -30,10 +35,29 @@ import { GetStringDescriptor } from './string/string';
 import { GetTypeAliasDescriptor } from './typeAlias/typeAlias';
 import { GetTypeLiteralDescriptor } from './typeLiteral/typeLiteral';
 import { GetTypeParameterDescriptor } from './typeParameter/typeParameter';
-import { GetTypeQueryDescriptor } from './typeQuery/typeQuery';
 import { GetTypeReferenceDescriptor } from './typeReference/typeReference';
 import { GetUndefinedDescriptor } from './undefined/undefined';
 import { GetUnionDescriptor } from './union/union';
+import GetFirstValidDeclaration = TypescriptHelper.GetFirstValidDeclaration;
+
+function GetTypeQueryDescriptor(node: ts.TypeQueryNode, scope: Scope): ts.Expression {
+    const declaration = TypescriptHelper.GetDeclarationFromNode(node.exprName);
+    
+    switch(declaration.kind) {
+        case ts.SyntaxKind.ClassDeclaration:
+            return TypescriptCreator.createFunctionExpressionReturn(GetClassDeclarationDescriptor(declaration as ts.ClassDeclaration, scope));
+        case ts.SyntaxKind.EnumDeclaration:
+            // MockDefiner.instance.addImportIdentifierOnFile('./enums', node.exprName as ts.Identifier);
+            // const typeChecker: ts.TypeChecker = TypeChecker();
+            // const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node.exprName);
+            // printer(GetFirstValidDeclaration(symbol.declarations).parent.parent);
+            // console.log(GetFirstValidDeclaration(symbol.declarations).parent.parent);
+            // GetFirstValidDeclaration(symbol.declarations).parent.parent.flags, ts.EmitFlags.);
+            return node.exprName as ts.Identifier;
+    }
+    
+    return GetNullDescriptor();
+}
 
 export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
     switch (node.kind) {

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -1,11 +1,7 @@
 import * as ts from 'typescript';
-import { printer } from '../../printer';
-import { TypescriptCreator } from '../helper/creator';
 import { TransformerLogger } from '../logger/transformerLogger';
-import { MockDefiner } from '../mockDefiner/mockDefiner';
-import { GetMockFactoryCall, GetMockFactoryCallForThis } from '../mockFactoryCall/mockFactoryCall';
+import { GetMockFactoryCallForThis } from '../mockFactoryCall/mockFactoryCall';
 import { Scope } from '../scope/scope';
-import { TypeChecker } from '../typeChecker/typeChecker';
 import { GetArrayDescriptor } from './array/array';
 import { GetBooleanDescriptor } from './boolean/boolean';
 import { GetBooleanFalseDescriptor } from './boolean/booleanFalse';
@@ -14,7 +10,6 @@ import { GetClassDeclarationDescriptor } from './class/classDeclaration';
 import { GetConstructorTypeDescriptor } from './constructor/constructorType';
 import { GetEnumDeclarationDescriptor } from './enum/enumDeclaration';
 import { GetExpressionWithTypeArgumentsDescriptor } from './expression/expressionWithTypeArguments';
-import { TypescriptHelper } from './helper/helper';
 import { GetIdentifierDescriptor } from './identifier/identifier';
 import { GetImportDescriptor } from './import/import';
 import { GetImportEqualsDescriptor } from './import/importEquals';
@@ -35,29 +30,10 @@ import { GetStringDescriptor } from './string/string';
 import { GetTypeAliasDescriptor } from './typeAlias/typeAlias';
 import { GetTypeLiteralDescriptor } from './typeLiteral/typeLiteral';
 import { GetTypeParameterDescriptor } from './typeParameter/typeParameter';
+import { GetTypeQueryDescriptor } from './typeQuery/typeQuery';
 import { GetTypeReferenceDescriptor } from './typeReference/typeReference';
 import { GetUndefinedDescriptor } from './undefined/undefined';
 import { GetUnionDescriptor } from './union/union';
-import GetFirstValidDeclaration = TypescriptHelper.GetFirstValidDeclaration;
-
-function GetTypeQueryDescriptor(node: ts.TypeQueryNode, scope: Scope): ts.Expression {
-    const declaration = TypescriptHelper.GetDeclarationFromNode(node.exprName);
-    
-    switch(declaration.kind) {
-        case ts.SyntaxKind.ClassDeclaration:
-            return TypescriptCreator.createFunctionExpressionReturn(GetClassDeclarationDescriptor(declaration as ts.ClassDeclaration, scope));
-        case ts.SyntaxKind.EnumDeclaration:
-            // MockDefiner.instance.addImportIdentifierOnFile('./enums', node.exprName as ts.Identifier);
-            // const typeChecker: ts.TypeChecker = TypeChecker();
-            // const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node.exprName);
-            // printer(GetFirstValidDeclaration(symbol.declarations).parent.parent);
-            // console.log(GetFirstValidDeclaration(symbol.declarations).parent.parent);
-            // GetFirstValidDeclaration(symbol.declarations).parent.parent.flags, ts.EmitFlags.);
-            return node.exprName as ts.Identifier;
-    }
-    
-    return GetNullDescriptor();
-}
 
 export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
     switch (node.kind) {
@@ -92,6 +68,8 @@ export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
             return GetImportDescriptor(node as ts.ImportClause, scope);
         case ts.SyntaxKind.MethodSignature:
             return GetMethodSignatureDescriptor(node as ts.MethodSignature, scope);
+        case ts.SyntaxKind.FunctionDeclaration:
+            return GetMethodDeclarationDescriptor(node as ts.FunctionDeclaration, scope);
         case ts.SyntaxKind.MethodDeclaration:
             return GetMethodDeclarationDescriptor(node as ts.MethodDeclaration, scope);
         case ts.SyntaxKind.FunctionType:

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -30,6 +30,7 @@ import { GetStringDescriptor } from './string/string';
 import { GetTypeAliasDescriptor } from './typeAlias/typeAlias';
 import { GetTypeLiteralDescriptor } from './typeLiteral/typeLiteral';
 import { GetTypeParameterDescriptor } from './typeParameter/typeParameter';
+import { GetTypeQueryDescriptor } from './typeQuery/typeQuery';
 import { GetTypeReferenceDescriptor } from './typeReference/typeReference';
 import { GetUndefinedDescriptor } from './undefined/undefined';
 import { GetUnionDescriptor } from './union/union';
@@ -80,6 +81,8 @@ export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
             return GetFunctionAssignmentDescriptor(node as ts.ArrowFunction, scope);
         case ts.SyntaxKind.ConstructorType:
             return GetConstructorTypeDescriptor(node as ts.ConstructorTypeNode, scope);
+        case ts.SyntaxKind.TypeQuery:
+            return GetTypeQueryDescriptor(node as ts.TypeQueryNode, scope);
         case ts.SyntaxKind.UnionType:
             return GetUnionDescriptor(node as ts.UnionTypeNode, scope);
         case ts.SyntaxKind.IntersectionType:

--- a/src/transformer/descriptor/helper/helper.ts
+++ b/src/transformer/descriptor/helper/helper.ts
@@ -31,24 +31,15 @@ export namespace TypescriptHelper {
     export function GetDeclarationForImport(node: ts.ImportClause | ts.ImportSpecifier): ts.TypeNode | ts.Declaration {
         const typeChecker: ts.TypeChecker = TypeChecker();
         const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node.name);
-        const declaredType: ts.Type = typeChecker.getDeclaredTypeOfSymbol(symbol);
-        return GetDeclarationFromType(declaredType);
+        const originalSymbol: ts.Symbol = typeChecker.getAliasedSymbol(symbol);
+
+        return GetFirstValidDeclaration(originalSymbol.declarations);
     }
 
     export function GetParameterOfNode(node: ts.EntityName): ts.NodeArray<ts.TypeParameterDeclaration> {
         const declaration: ts.Declaration = GetDeclarationFromNode(node);
 
         return (declaration as Declaration).typeParameters;
-    }
-
-    export function GetDeclarationFromType(type: ts.Type): ts.TypeNode | ts.Declaration {
-        if (type.symbol && type.symbol.declarations) {
-            return GetFirstValidDeclaration(type.symbol.declarations);
-        } else if (type.aliasSymbol && type.aliasSymbol.declarations) {
-            return GetFirstValidDeclaration(type.aliasSymbol.declarations);
-        }
-
-        return TypeChecker().typeToTypeNode(type);
     }
 
     export function GetTypeParameterOwnerMock(declaration: ts.Declaration): ts.Declaration {

--- a/src/transformer/descriptor/helper/helper.ts
+++ b/src/transformer/descriptor/helper/helper.ts
@@ -15,6 +15,10 @@ export namespace TypescriptHelper {
     export function GetDeclarationFromNode(node: ts.Node): ts.Declaration {
         const typeChecker: ts.TypeChecker = TypeChecker();
         const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node);
+        return GetDeclarationFromSymbol(symbol);
+    }
+
+    export function GetDeclarationFromSymbol(symbol: ts.Symbol): ts.Declaration {
         const declaration: ts.Declaration = GetFirstValidDeclaration(symbol.declarations);
 
         if (ts.isImportSpecifier(declaration)) {
@@ -60,6 +64,6 @@ export namespace TypescriptHelper {
     function GetFirstValidDeclaration(declarations: ts.Declaration[]): ts.Declaration {
         return declarations.find((declaration: ts.Declaration) => {
             return !ts.isVariableDeclaration(declaration);
-        });
+        }) || declarations[0];
     }
 }

--- a/src/transformer/descriptor/method/bodyReturnType.ts
+++ b/src/transformer/descriptor/method/bodyReturnType.ts
@@ -3,7 +3,7 @@ import { Scope } from '../../scope/scope';
 import { GetDescriptor } from '../descriptor';
 import { GetNullDescriptor } from '../null/null';
 
-export function GetReturnTypeFromBody(node: ts.ArrowFunction | ts.FunctionExpression | ts.MethodDeclaration, scope: Scope): ts.Expression {
+export function GetReturnTypeFromBody(node: ts.ArrowFunction | ts.FunctionExpression | ts.MethodDeclaration | ts.FunctionDeclaration, scope: Scope): ts.Expression {
     let returnValue: ts.Expression;
 
     const functionBody: ts.FunctionBody = node.body as ts.FunctionBody;

--- a/src/transformer/descriptor/method/methodDeclaration.ts
+++ b/src/transformer/descriptor/method/methodDeclaration.ts
@@ -4,7 +4,7 @@ import { GetDescriptor } from '../descriptor';
 import { GetReturnTypeFromBody } from './bodyReturnType';
 import { GetMethodDescriptor } from './method';
 
-export function GetMethodDeclarationDescriptor(node: ts.MethodDeclaration, scope: Scope): ts.Expression {
+export function GetMethodDeclarationDescriptor(node: ts.MethodDeclaration | ts.FunctionDeclaration, scope: Scope): ts.Expression {
     let returnType: ts.Expression;
 
     if (node.type) {

--- a/src/transformer/descriptor/mock/mockProperties.ts
+++ b/src/transformer/descriptor/mock/mockProperties.ts
@@ -10,11 +10,14 @@ export function GetMockPropertiesFromSymbol(propertiesSymbol: ts.Symbol[], signa
     const properties: ts.Declaration[] = propertiesSymbol.map((prop: ts.Symbol) => {
         return prop.declarations[0];
     });
+    const signaturesDeclarations: ts.Declaration[] = signatures.map((signature: ts.Signature) => {
+        return signature.declaration;
+    });
 
-    return GetMockPropertiesFromDeclarations(properties, signatures, scope);
+    return GetMockPropertiesFromDeclarations(properties, signaturesDeclarations, scope);
 }
 
-export function GetMockPropertiesFromDeclarations(list: ts.Declaration[], signatures: ReadonlyArray<ts.Signature>, scope: Scope): ts.CallExpression {
+export function GetMockPropertiesFromDeclarations(list: ReadonlyArray<ts.Declaration>, signatures: ReadonlyArray<ts.Declaration>, scope: Scope): ts.CallExpression {
     const propertiesFilter: ts.Declaration[] = list.filter((member: ts.PropertyDeclaration) => {
         const hasModifiers: boolean = !!member.modifiers;
 
@@ -42,6 +45,6 @@ export function GetMockPropertiesFromDeclarations(list: ts.Declaration[], signat
         },
     );
 
-    const signaturesDescriptor: ts.Expression = signatures.length > 0 ? GetDescriptor(signatures[0].declaration, scope) : null;
+    const signaturesDescriptor: ts.Expression = signatures.length > 0 ? GetDescriptor(signatures[0], scope) : null;
     return GetMockCall(variableDeclarations, accessorDeclaration, signaturesDescriptor);
 }

--- a/src/transformer/descriptor/properties/properties.ts
+++ b/src/transformer/descriptor/properties/properties.ts
@@ -2,16 +2,38 @@ import { SignatureKind } from 'typescript';
 import * as ts from 'typescript';
 import { Scope } from '../../scope/scope';
 import { TypeChecker } from '../../typeChecker/typeChecker';
-import { GetMockPropertiesFromSymbol } from '../mock/mockProperties';
+import { GetMockPropertiesFromDeclarations, GetMockPropertiesFromSymbol } from '../mock/mockProperties';
 
 export function GetProperties(node: ts.Node, scope: Scope): ts.Expression {
     const typeChecker: ts.TypeChecker = TypeChecker();
     const type: ts.Type = typeChecker.getTypeAtLocation(node);
     const symbols: ts.Symbol[] = typeChecker.getPropertiesOfType(type);
 
-    const signatures: Array<ts.Signature> = [];
-    Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Call));
-    Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Construct));
+    if (!symbols.length) {
+        return GetPropertiesFromMembers(node as ts.TypeLiteralNode, scope);
+    } else {
+        const signatures: Array<ts.Signature> = [];
 
-    return GetMockPropertiesFromSymbol(symbols, signatures, scope);
+        Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Call));
+        Array.prototype.push.apply(signatures, typeChecker.getSignaturesOfType(type, SignatureKind.Construct));
+
+        return GetMockPropertiesFromSymbol(symbols, signatures, scope);
+    }
+}
+
+export function GetPropertiesFromMembers(node: ts.TypeLiteralNode, scope: Scope): ts.Expression {
+    const members: ts.NodeArray<ts.NamedDeclaration> = node.members;
+    const signatures: Array<ts.Declaration> = [];
+    const properties: Array<ts.Declaration> = [];
+
+    // tslint:disable-next-line
+    for (let i: number = 0; i < members.length; i++) {
+        if (members[i].kind === ts.SyntaxKind.CallSignature || members[i].kind === ts.SyntaxKind.ConstructSignature) {
+            signatures.push(members[i]);
+        } else if (members[i].kind === ts.SyntaxKind.PropertyDeclaration || members[i].kind === ts.SyntaxKind.PropertySignature || members[i].kind === ts.SyntaxKind.MethodSignature) {
+            properties.push(members[i]);
+        }
+    }
+
+    return GetMockPropertiesFromDeclarations(properties, signatures, scope);
 }

--- a/src/transformer/descriptor/typeQuery/enumTypeQuery.ts
+++ b/src/transformer/descriptor/typeQuery/enumTypeQuery.ts
@@ -1,0 +1,22 @@
+import * as ts from 'typescript';
+import { Scope } from '../../scope/scope';
+
+export function GetTypeofEnumDescriptor(enumDeclaration: ts.EnumDeclaration, scope: Scope): ts.Expression {
+  enumDeclaration.modifiers = undefined;
+  enumDeclaration.name = ts.createFileLevelUniqueName(enumDeclaration.name.text);
+
+  return ts.createArrowFunction(
+    undefined,
+    undefined,
+    [],
+    ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+    ts.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+    ts.createBlock(
+      [
+        enumDeclaration,
+        ts.createReturn(enumDeclaration.name),
+      ],
+      true,
+    ),
+  );
+}

--- a/src/transformer/descriptor/typeQuery/typeQuery.ts
+++ b/src/transformer/descriptor/typeQuery/typeQuery.ts
@@ -3,13 +3,28 @@ import { TypescriptCreator } from '../../helper/creator';
 import { TransformerLogger } from '../../logger/transformerLogger';
 import { GetMockFactoryCallTypeofEnum } from '../../mockFactoryCall/mockFactoryCall';
 import { Scope } from '../../scope/scope';
+import { TypeChecker } from '../../typeChecker/typeChecker';
+import { GetDescriptor } from '../descriptor';
 import { TypescriptHelper } from '../helper/helper';
 import { GetMethodDeclarationDescriptor } from '../method/methodDeclaration';
 import { GetNullDescriptor } from '../null/null';
 import { GetTypeReferenceDescriptor } from '../typeReference/typeReference';
 
 export function GetTypeQueryDescriptor(node: ts.TypeQueryNode, scope: Scope): ts.Expression {
-  const declaration: ts.Declaration = TypescriptHelper.GetDeclarationFromNode(node.exprName);
+  const typeChecker: ts.TypeChecker = TypeChecker();
+  /*
+   TODO: Find different workaround without casting to any
+   Cast to any is been done because getSymbolAtLocation doesn't work when the node is an inferred identifier of a type query of a type query
+   Use case is:
+   ```
+   const myVar = MyEnum;
+   createMock<typeof myVar>();
+   ```
+   here `typeof myVar` is inferred `typeof MyEnum` and the `MyEnum` identifier doesn't play well with getSymbolAtLocation and it returns undefined.
+  */
+  // tslint:disable-next-line no-any
+  const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node.exprName) || (node.exprName as any).symbol;
+  const declaration: ts.Declaration = TypescriptHelper.GetDeclarationFromSymbol(symbol);
 
   switch (declaration.kind) {
     case ts.SyntaxKind.ClassDeclaration:
@@ -26,6 +41,9 @@ export function GetTypeQueryDescriptor(node: ts.TypeQueryNode, scope: Scope): ts
       return GetMockFactoryCallTypeofEnum(declaration as ts.EnumDeclaration);
     case ts.SyntaxKind.FunctionDeclaration:
       return GetMethodDeclarationDescriptor(declaration as ts.FunctionDeclaration, scope);
+    case ts.SyntaxKind.VariableDeclaration:
+      const typeNode: ts.TypeNode = (declaration as ts.VariableDeclaration).type || typeChecker.typeToTypeNode(typeChecker.getTypeFromTypeNode(node));
+      return GetDescriptor(typeNode, scope);
     default:
       TransformerLogger().typeNotSupported(`TypeQuery of ${ts.SyntaxKind[declaration.kind]}`);
       return GetNullDescriptor();

--- a/src/transformer/descriptor/typeQuery/typeQuery.ts
+++ b/src/transformer/descriptor/typeQuery/typeQuery.ts
@@ -1,0 +1,33 @@
+import * as ts from 'typescript';
+import { TypescriptCreator } from '../../helper/creator';
+import { TransformerLogger } from '../../logger/transformerLogger';
+import { GetMockFactoryCallTypeofEnum } from '../../mockFactoryCall/mockFactoryCall';
+import { Scope } from '../../scope/scope';
+import { TypescriptHelper } from '../helper/helper';
+import { GetMethodDeclarationDescriptor } from '../method/methodDeclaration';
+import { GetNullDescriptor } from '../null/null';
+import { GetTypeReferenceDescriptor } from '../typeReference/typeReference';
+
+export function GetTypeQueryDescriptor(node: ts.TypeQueryNode, scope: Scope): ts.Expression {
+  const declaration: ts.Declaration = TypescriptHelper.GetDeclarationFromNode(node.exprName);
+
+  switch (declaration.kind) {
+    case ts.SyntaxKind.ClassDeclaration:
+      return TypescriptCreator.createFunctionExpressionReturn(
+        GetTypeReferenceDescriptor(
+          ts.createTypeReferenceNode(node.exprName as ts.Identifier, undefined),
+          scope,
+        ),
+      );
+    case ts.SyntaxKind.EnumDeclaration:
+      // TODO: Use following two lines when issue #17552 on typescript github is resolved (https://github.com/microsoft/TypeScript/issues/17552)
+      // TheNewEmitResolver.ensureEmitOf(GetImportDeclarationOf(node.eprName as ts.Identifier);
+      // return node.exprName as ts.Identifier;
+      return GetMockFactoryCallTypeofEnum(declaration as ts.EnumDeclaration);
+    case ts.SyntaxKind.FunctionDeclaration:
+      return GetMethodDeclarationDescriptor(declaration as ts.FunctionDeclaration, scope);
+    default:
+      TransformerLogger().typeNotSupported(`TypeQuery of ${ts.SyntaxKind[declaration.kind]}`);
+      return GetNullDescriptor();
+  }
+}

--- a/src/transformer/mockDefiner/mockDefiner.ts
+++ b/src/transformer/mockDefiner/mockDefiner.ts
@@ -62,15 +62,24 @@ export class MockDefiner {
     }
 
     public setTsAutoMockImportIdentifier(): void {
-        if (!this._neededImportIdentifierPerFile[this._fileName]) {
-            this._neededImportIdentifierPerFile[this._fileName] = Object.keys(ModulesImportUrl).map((key: ModuleName) => {
-                return {
-                    name: key,
-                    moduleUrl: ModulesImportUrl[key],
-                    identifier: this._createUniqueFileName(key),
-                };
-            });
-        }
+        this._neededImportIdentifierPerFile[this._fileName] = this._neededImportIdentifierPerFile[this._fileName] || [];
+        
+        Array.prototype.push.apply(this._neededImportIdentifierPerFile[this._fileName], Object.keys(ModulesImportUrl).map((key: ModuleName) => {
+            return {
+                name: key,
+                moduleUrl: ModulesImportUrl[key],
+                identifier: this._createUniqueFileName(key),
+            };
+        }));
+    }
+
+    public addImportIdentifierOnFile(name: string, url: string, identifier: ts.Identifier): void {
+        this._neededImportIdentifierPerFile[this._fileName] = this._neededImportIdentifierPerFile[this._fileName] || [];
+        this._neededImportIdentifierPerFile[this._fileName].push({
+            name: name as any,
+            moduleUrl: url as any,
+            identifier: identifier,
+        });
     }
 
     public getCurrentModuleIdentifier(module: ModuleName): ts.Identifier {

--- a/src/transformer/mockDefiner/modules/moduleNameIdentifier.ts
+++ b/src/transformer/mockDefiner/modules/moduleNameIdentifier.ts
@@ -1,9 +1,6 @@
 import * as ts from 'typescript';
-import { ModuleName } from './moduleName';
-import { ModuleImportUrl } from './modulesImportUrl';
 
 export interface ModuleNameIdentifier {
-    name: ModuleName;
-    moduleUrl: ModuleImportUrl;
+    moduleUrl: string;
     identifier: ts.Identifier;
 }

--- a/src/transformer/mockFactoryCall/mockFactoryCall.ts
+++ b/src/transformer/mockFactoryCall/mockFactoryCall.ts
@@ -57,6 +57,16 @@ export function GetMockFactoryCallIntersection(intersection: ts.IntersectionType
     );
 }
 
+export function GetMockFactoryCallTypeofEnum(declaration: ts.EnumDeclaration): ts.Expression {
+    const mockFactoryCall: ts.Expression = MockDefiner.instance.getMockFactoryTypeofEnum(declaration);
+
+    return ts.createCall(
+        mockFactoryCall,
+        [],
+        [],
+    );
+}
+
 export function GetMockFactoryCallForThis(mockKey: string): ts.Expression {
     const mockFactoryCall: ts.Expression = MockDefiner.instance.getMockFactoryByKey(mockKey);
 

--- a/test/playground/enums.ts
+++ b/test/playground/enums.ts
@@ -1,5 +1,5 @@
 export enum MyEnum {
   A,
   B,
-  C
+  C = "OK"
 }

--- a/test/playground/enums.ts
+++ b/test/playground/enums.ts
@@ -1,0 +1,5 @@
+export enum MyEnum {
+  A,
+  B,
+  C
+}

--- a/test/playground/playground.test.ts
+++ b/test/playground/playground.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { MyEnum } from './enums';
 
 /*
  USE THIS FILE ONLY FOR TESTING NEW IMPLEMENTATION
@@ -9,16 +10,11 @@ import { createMock } from 'ts-auto-mock';
  */
 
 it('should work', () => {
-    interface Newable {
-        b: string;
+    interface A {
+        
     }
-    
-    interface Interface {
-        a: new () => Newable;
-        b: Newable;
-    }
+    const enumm2: typeof MyEnum = createMock<typeof MyEnum>();
+    createMock<A>();
 
-    const properties: Interface = createMock<Interface>();
-
-    expect(new (properties.a)().b).toEqual('');
+    expect(enumm2.A).toEqual(0);
 });

--- a/test/transformer/descriptor/literal/literal.test.ts
+++ b/test/transformer/descriptor/literal/literal.test.ts
@@ -82,9 +82,9 @@ describe('for literal', () => {
             literal: TypeUnionTokenAllBoolean;
         }
 
-        it('should treat it as if it is boolean and set false', () => {
+        it('should set the first boolean value', () => {
             const properties: Interface = createMock<Interface>();
-            expect(properties.literal).toBe(false);
+            expect(properties.literal).toBe(true);
         });
     });
 

--- a/test/transformer/descriptor/typeQuery/typeQuery.test.ts
+++ b/test/transformer/descriptor/typeQuery/typeQuery.test.ts
@@ -1,0 +1,101 @@
+import { createMock } from 'ts-auto-mock';
+import {
+  ExportedClass,
+  ExportedDeclaredClass,
+  exportedDeclaredFunction, ExportedEnum,
+  exportedFunction, WrapExportedClass, WrapExportedEnum,
+} from '../utils/typeQuery/typeQueryUtils';
+
+declare function functionDeclaration(): number;
+
+describe('typeQuery', () => {
+  describe('for function', () => {
+    it('should assign the function mock for a function declaration', () => {
+      const functionMock: typeof functionDeclaration = createMock<typeof functionDeclaration>();
+
+      expect(functionMock()).toEqual(0);
+    });
+
+    it('should assign the function mock for an function declaration with body', () => {
+      function func(): string {
+        return 'ok';
+      }
+
+      const functionMock: typeof func = createMock<typeof func>();
+
+      expect(functionMock()).toEqual('');
+    });
+
+    it('should assign the function mock for an imported function declaration', () => {
+      const functionMock: typeof exportedDeclaredFunction = createMock<typeof exportedDeclaredFunction>();
+
+      expect(functionMock()).toEqual('');
+    });
+
+    it('should assign the function mock for an imported function declaration with body', () => {
+      const functionMock: typeof exportedFunction = createMock<typeof exportedFunction>();
+
+      expect(functionMock()).toEqual(0);
+    });
+  });
+
+  describe('for class', () => {
+    it('should create a newable class for an imported class declaration', () => {
+      const classMock: typeof ExportedDeclaredClass = createMock<typeof ExportedDeclaredClass>();
+
+      expect(new classMock().prop).toEqual('');
+    });
+
+    it('should create a newable class for an imported class', () => {
+      const classMock: typeof ExportedClass = createMock<typeof ExportedClass>();
+
+      expect(new classMock().prop).toEqual(0);
+    });
+
+    it('should create a newable class for an wrapped imported typeof class', () => {
+      const classMock: WrapExportedClass = createMock<WrapExportedClass>();
+
+      expect(new classMock().prop).toEqual(0);
+    });
+  });
+
+  describe('for enum', () => {
+    it('should assign the enum to the mock', () => {
+      enum Enum {
+        A,
+        B = 'some'
+      }
+
+      const enumMock: typeof Enum = createMock<typeof Enum>();
+
+      expect(enumMock.A).toEqual(0);
+      expect(enumMock.B).toEqual('some');
+    });
+
+    it('should assign the imported enum to the mock', () => {
+      const enumMock: typeof ExportedEnum = createMock<typeof ExportedEnum>();
+
+      expect(enumMock.A).toEqual(0);
+      expect(enumMock.B).toEqual('B');
+      expect(enumMock.C).toEqual('MaybeC');
+    });
+
+    it('should assign the imported enum to the mock when typeof wrapped in a type', () => {
+      type WrapEnum = typeof ExportedEnum;
+
+      const enumMock: WrapEnum = createMock<WrapEnum>();
+
+      expect(enumMock.A).toEqual(0);
+      expect(enumMock.B).toEqual('B');
+      expect(enumMock.C).toEqual('MaybeC');
+    });
+
+    it('should assign the enum to the mock when importing enum wrapper', () => {
+      const enumMock: WrapExportedEnum = createMock<WrapExportedEnum>();
+
+      expect(enumMock.A).toEqual(0);
+      expect(enumMock.B).toEqual('B');
+      expect(enumMock.C).toEqual('MaybeC');
+    });
+  });
+});

--- a/test/transformer/descriptor/typeQuery/typeQuery.test.ts
+++ b/test/transformer/descriptor/typeQuery/typeQuery.test.ts
@@ -1,4 +1,6 @@
 import { createMock } from 'ts-auto-mock';
+import { MyEnum } from '../../../playground/enums';
+import { ImportInterface } from '../utils/interfaces/importInterface';
 import {
   ExportedClass,
   ExportedDeclaredClass,
@@ -96,6 +98,58 @@ describe('typeQuery', () => {
       expect(enumMock.A).toEqual(0);
       expect(enumMock.B).toEqual('B');
       expect(enumMock.C).toEqual('MaybeC');
+    });
+  });
+
+  describe('for variable', () => {
+    it('should create the imported interface mock from the type of a variable', () => {
+      let aVariable: ImportInterface;
+
+      const mock: typeof aVariable = createMock<typeof aVariable>();
+
+      expect(mock.a.b).toEqual('');
+    });
+
+    it('should create the imported typeof enum mock from the type of a variable', () => {
+      let aVariable: WrapExportedEnum;
+
+      const mock: typeof aVariable = createMock<typeof aVariable>();
+
+      expect(mock.A).toEqual(0);
+    });
+
+    describe('inferred type', () => {
+      it('should work for inferred object', () => {
+        const aVariable = { prop: 'asd' };
+
+        const mock: typeof aVariable = createMock<typeof aVariable>();
+
+        expect(mock.prop).toEqual('');
+      });
+      
+      it('should work for enum', () => {
+        const aVariable = MyEnum;
+
+        const mock: typeof aVariable = createMock<typeof aVariable>();
+
+        expect(mock.A).toEqual(0);
+      });
+      
+      it('should work for function call', () => {
+        function test(value) {
+          if(value) {
+            return { prop: 'asd' };
+          }
+          
+          return { second: 7 };
+        }
+
+        const aVariable = test(true);
+
+        const mock: typeof aVariable = createMock<typeof aVariable>();
+
+        expect(mock.prop).toEqual('');
+      });
     });
   });
 });

--- a/test/transformer/descriptor/utils/typeQuery/typeQueryUtils.ts
+++ b/test/transformer/descriptor/utils/typeQuery/typeQueryUtils.ts
@@ -1,0 +1,20 @@
+export declare function exportedDeclaredFunction(): string;
+
+export declare class ExportedDeclaredClass {
+  prop: string;
+}
+
+export function exportedFunction(): number { return 3; }
+
+export class ExportedClass {
+  prop: number;
+}
+
+export enum ExportedEnum {
+  A,
+  B = 'B',
+  C = 'MaybeC'
+}
+
+export type WrapExportedEnum = typeof ExportedEnum;
+export type WrapExportedClass = typeof ExportedClass;


### PR DESCRIPTION
This will fix #91 

I've changed how an import of a type `true|false` works, before was behaving in the same way as Boolean, now it works like a normal union picking the first value.

I had to recreate the enum mock even if it wouldn't be needed (the enum is a constant) because there is no way to force the import to stay there. The best solution is for `typeof Enum` to just assign the Enum identifier forcing the import to not disappear. We can do that when https://github.com/microsoft/TypeScript/issues/17552 gets resolved.

To be able to reuse the enum mock I had to create a new parallel process for it, ideally that will be deleted (due to the above statement).

I've changed how we store imports... because I didn't like the loop that we had. Now to get the import identifier of a module we have a map and the imports are agnostic of the fact that are only for internal modules (in this way it's open for custom imports).

I've just covered:
typeof enum
typeof class
typeof function
typeof variable

I can't think of anything else, let me know.

There are two TODOs in this PR, both of them are there because either typescript is missing some features or I don't know how to work with those cases.