### PR TITLE
fix(definitelyTyped): add node types in generated tsconfig

### DIFF
--- a/definitelyTypedTests/index.js
+++ b/definitelyTypedTests/index.js
@@ -93,7 +93,7 @@ async function run(dir, processId) {
             'typeRoots': [
                 definitelyTyped.typesFolder
             ],
-            'types': [],
+            'types': ['node'],
             'baseUrl': definitelyTyped.typesFolder
         },
         'files': [


### PR DESCRIPTION
Currently types like `gen-readlines` fails with the message:
```
error TS2591: Cannot find name 'Buffer'.
Do you need to install type definitions for node?
Try `npm i @types/node` and then add `node` to the types field in your tsconfig.
```

With this PR I'm adding 'node' in the list of types to fix it.