### PR TITLE
build(create-pull-request): make sure we're more lenient with versions of create-pull-request

### DIFF
--- a/.github/workflows/definitelyTyped.yml
+++ b/.github/workflows/definitelyTyped.yml
@@ -38,7 +38,7 @@ jobs:
           git add data/*
           git checkout .
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2.0.0
+        uses: peter-evans/create-pull-request@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_TYPESCRIPTTDD }}
         with:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -40,7 +40,7 @@ jobs:
         git config --global user.name 'typescripttdd'
         git config --global user.email 'typescripttdd@gmail.com'
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v2.0.0
+      uses: peter-evans/create-pull-request@v2
       with:
         commit-message: Add Performance data
         committer: typescripttdd <typescripttdd@gmail.com>


### PR DESCRIPTION
This PR makes sure that when create-pull-request action package makes a new version (keeping the major version 2) we use it without having to update the yml files.