### PR TITLE
fix/typescript-types make sure that typescript type name is always returned so it will be possible to convert it to the correct one

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -139,7 +139,7 @@
     "no-bitwise": "error",
     "no-caller": "error",
     "no-cond-assign": "error",
-    "no-console": "error",
+    "no-console": "warn",
     "no-debugger": "error",
     "no-empty": "error",
     "no-eval": "error",

--- a/src/transformer/descriptor/tsLibs/typescriptLibsTypeAdapter.ts
+++ b/src/transformer/descriptor/tsLibs/typescriptLibsTypeAdapter.ts
@@ -2,17 +2,13 @@ import * as ts from 'typescript';
 import { Scope } from '../../scope/scope';
 import { TypeChecker } from '../../typeChecker/typeChecker';
 import { GetDescriptor } from '../descriptor';
-import { TypescriptHelper } from '../helper/helper';
 import { GetUndefinedDescriptor } from '../undefined/undefined';
 import { TypescriptLibsTypes } from './typescriptLibsTypes';
 
 export function TypescriptLibsTypeAdapter(node: ts.TypeReferenceNode, scope: Scope): ts.Node {
-  const declaration: ts.Declaration = TypescriptHelper.GetDeclarationFromNode(node.typeName);
   const typeChecker: ts.TypeChecker = TypeChecker();
-  const type: ts.Type = typeChecker.getTypeAtLocation(declaration);
-  const name: string = type.symbol?.name || type.aliasSymbol.name;
-
-  const typeScriptType: TypescriptLibsTypes = TypescriptLibsTypes[name];
+  const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node.typeName);
+  const typeScriptType: TypescriptLibsTypes = TypescriptLibsTypes[symbol.name];
 
   switch (typeScriptType) {
   case(TypescriptLibsTypes.Array):

--- a/src/transformer/descriptor/tsLibs/typescriptLibsTypeAdapter.ts
+++ b/src/transformer/descriptor/tsLibs/typescriptLibsTypeAdapter.ts
@@ -10,7 +10,9 @@ export function TypescriptLibsTypeAdapter(node: ts.TypeReferenceNode, scope: Sco
   const declaration: ts.Declaration = TypescriptHelper.GetDeclarationFromNode(node.typeName);
   const typeChecker: ts.TypeChecker = TypeChecker();
   const type: ts.Type = typeChecker.getTypeAtLocation(declaration);
-  const typeScriptType: TypescriptLibsTypes = TypescriptLibsTypes[type.symbol.name];
+  const name: string = type.symbol?.name || type.aliasSymbol.name;
+
+  const typeScriptType: TypescriptLibsTypes = TypescriptLibsTypes[name];
 
   switch (typeScriptType) {
   case(TypescriptLibsTypes.Array):

--- a/test/transformer/descriptor/tsLibs/tsLibs.test.ts
+++ b/test/transformer/descriptor/tsLibs/tsLibs.test.ts
@@ -194,11 +194,20 @@ describe('typescript lib', () => {
         expect(result).toBe('');
   });
 
-
   it('should set a promise resolved for a type mocked directly', async () => {
         type S<T> = Promise<T>;
         const properties: S<string> = createMock<S<string>>();
         const result: string = await properties;
         expect(result).toBe('');
+  });
+
+  it('should set undefined for a not recognized type alias declaration', () => {
+    interface WithLiteralTypescriptType {
+      prop: InsertPosition;
+    }
+
+    const mock: WithLiteralTypescriptType = createMock<WithLiteralTypescriptType>();
+
+    expect(mock.prop).toBeUndefined();
   });
 });

--- a/tsconfig.playground.json
+++ b/tsconfig.playground.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "test/playground/playground.test.ts"
-  ]
+  ],
+  "include": []
 }
 


### PR DESCRIPTION
I've found a small issue in our typescript conversion.

to understand how we will perform the conversion we were trying to get the name of the type (Promise, Array, ...)

For types like this one we were not able to retrieve the name (InsertPosition)
```ts
 type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";
```
I've added a fix. to resolve the aliasSymbol when symbol is not present.

Looking at the code I realise that any typescript type that we don't support it will be converted to Undefined. Considering that this library now its in a good shape I would like to try to re enable typescript types except the one that we want to convert to their original value.

I think we should do it after we definitely typed issue will reach a 10% errors. Right now we have a 35% of errors.

