### PR TITLE
fix(mockProperty): make sure a falsy value can be assigned to a mock property

### DIFF
--- a/test/transformer/create-mock-values.test.ts
+++ b/test/transformer/create-mock-values.test.ts
@@ -1,9 +1,14 @@
 import { createMock } from 'ts-auto-mock';
 
 describe('create-mock-values', () => {
+  interface SubInterface {
+    property: number;
+  }
+
   interface Interface {
     property: string;
     method(): void;
+    subInterface: SubInterface;
   }
 
   it('should create the mock merging the values provided', () => {
@@ -13,5 +18,17 @@ describe('create-mock-values', () => {
 
     expect(properties.property).toBe('sss');
     properties.method();
+  });
+
+  it('should create the mock merging the null values provided', () => {
+    const properties: Interface = createMock<Interface>({
+      property: null,
+      method: null,
+      subInterface: null,
+    });
+
+    expect(properties.property).toBeNull();
+    expect(properties.method).toBeNull();
+    expect(properties.subInterface).toBeNull();
   });
 });

--- a/test/transformer/descriptor/properties/assignFalsy.test.ts
+++ b/test/transformer/descriptor/properties/assignFalsy.test.ts
@@ -1,0 +1,49 @@
+import { createMock } from 'ts-auto-mock';
+
+describe('mocking properties', () => {
+  describe('when property is a mock', () => {
+    interface SubInterface {
+      aProp: string;
+    }
+
+    interface AnInterface {
+      bProp: SubInterface;
+    }
+
+    it('should correctly assign null', () => {
+      const anInterface: AnInterface = createMock<AnInterface>();
+
+      anInterface.bProp = null;
+
+      expect(anInterface.bProp).toBeNull();
+    });
+  });
+
+  describe('when property is a value type', () => {
+    interface AnInterface {
+      aProp: string;
+    }
+
+    it('should correctly assign null', () => {
+      const anInterface: AnInterface = createMock<AnInterface>();
+
+      anInterface.aProp = null;
+
+      expect(anInterface.aProp).toBeNull();
+    });
+  });
+
+  describe('when property is a function', () => {
+    interface AnInterface {
+      aProp(): string;
+    }
+
+    it('should correctly assign null', () => {
+      const anInterface: AnInterface = createMock<AnInterface>();
+
+      anInterface.aProp = null;
+
+      expect(anInterface.aProp).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
With this PR the complex property getters will be changed from
```ts
get prop() {
  return m["prop"] || m["prop"] = createMock("some_token");
}
```

to

```ts
get prop() {
  return m.hasOwnProperty("prop") ? m["prop"] : m["prop"] = createMock("some_token");
}
```

In this way even by assigning a `null` value it won't create the mock.

This will close #207 