### PR TITLE
fix(transformer): export definitely typed for transformer so it will be easier to read the documentation while developing

### DIFF
--- a/config/modules/transformer/tsconfig.json
+++ b/config/modules/transformer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/transformer"
+    "declaration": true,
+    "outDir": "../../../dist"
   }
 }

--- a/config/modules/transformer/webpack.js
+++ b/config/modules/transformer/webpack.js
@@ -15,10 +15,9 @@ module.exports = merge(base({
         webpackNodeExternals()
     ],
     entry: {
-        index: './src/transformer/transformer.ts',
+        index: './src/transformer/index.ts',
     },
     output: {
         path: path.resolve(__dirname, "../../../dist/transformer"),
-        filename: "index.js"
     }
 });

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -1,0 +1,3 @@
+import { transformer } from './transformer';
+
+export default transformer;

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -5,7 +5,7 @@ import { getMock, getMockForList, storeRegisterMock } from './mock/mock';
 import { MockDefiner } from './mockDefiner/mockDefiner';
 import { SetTypeChecker, TypeChecker } from './typeChecker/typeChecker';
 
-export default function transformer(program: ts.Program, options?: TsAutoMockOptions): ts.TransformerFactory<ts.SourceFile> {
+export function transformer(program: ts.Program, options?: TsAutoMockOptions): ts.TransformerFactory<ts.SourceFile> {
   SetTsAutoMockOptions(options);
   SetTypeChecker(program.getTypeChecker());
 


### PR DESCRIPTION
I've added the export of d ts file for the transformer.

Note: 
I've also moved the default export in a different file, so if we have to swap in the future to a different transformer will be easier. I've tested it locally with jasmine-ts-auto-mock and it works.

Downside of this:

We are exporting plenty of d.ts files because when you set declaration true it will resolve all of the d.ts for the transformer (array, descriptor etc, etc). (Not sure yet if its worth limit it to the public interface and how)