### PR TITLE
feat(extendsMappedType): add support for extends mapped type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -106,7 +106,7 @@
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/unified-signatures": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
-    "arrow-body-style": "error",
+    "arrow-body-style": "off",
     "arrow-parens": [
       "error",
       "as-needed"

--- a/src/transformer/descriptor/helper/helper.ts
+++ b/src/transformer/descriptor/helper/helper.ts
@@ -18,6 +18,13 @@ export namespace TypescriptHelper {
     const typeChecker: ts.TypeChecker = TypeChecker();
     const symbol: ts.Symbol = typeChecker.getSymbolAtLocation(node);
 
+    if (!symbol) {
+      // When the node lose the type checker feature there is no way to use typeChecker to get information.
+      // However there is a symbol property that can be used instead,
+      const type: ts.Type = node as unknown as ts.Type;
+      return GetDeclarationFromSymbol(type.symbol);
+    }
+
     return GetDeclarationFromSymbol(symbol);
   }
 

--- a/test/transformer/descriptor/extends/mappedType.test.ts
+++ b/test/transformer/descriptor/extends/mappedType.test.ts
@@ -1,0 +1,50 @@
+import {createMock} from 'ts-auto-mock';
+
+describe('extends MappedType', () => {
+  enum SOME_ENUM {
+    FIRST = 'FIRST',
+    SECOND = 'SECOND',
+  }
+
+  type Dictionary<T extends string, S> = {[key in T]: S};
+
+  it('should be able to convert the interface type', () => {
+    interface IBase  {
+      propertyA: string;
+      propertyB: number;
+    }
+
+    interface InterfaceWithExtends extends Dictionary<SOME_ENUM, IBase> {}
+
+    const type: InterfaceWithExtends = createMock<InterfaceWithExtends>();
+    expect(type.FIRST.propertyA).toBe('');
+    expect(type.FIRST.propertyB).toBe(0);
+    expect(type.SECOND.propertyB).toBe(0);
+    expect(type.SECOND.propertyA).toBe('');
+  });
+
+  it('should be able to convert the primitive type', () => {
+    interface InterfaceWithExtends extends Dictionary<SOME_ENUM, string> {}
+
+    const type: InterfaceWithExtends = createMock<InterfaceWithExtends>();
+    expect(type.FIRST).toBe('');
+    expect(type.SECOND).toBe('');
+  });
+
+  it('should be able to convert the primitive type using Record', () => {
+    interface InterfaceWithExtends extends Record<SOME_ENUM, string> {}
+
+    const type: InterfaceWithExtends = createMock<InterfaceWithExtends>();
+    expect(type.FIRST).toBe('');
+    expect(type.SECOND).toBe('');
+  });
+
+  it('should be able to convert the literal type', () => {
+    interface InterfaceWithExtends extends Record<SOME_ENUM, {
+      propertyA: boolean;
+    }> {}
+
+    const type: InterfaceWithExtends = createMock<InterfaceWithExtends>();
+    expect(type.FIRST.propertyA).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR will make sure that if an interface/class extends a mapped type it will find the correct type
#238

I am not convinced 100% of the solution because it makes a lot of assumptions and is really difficult to read.

We can decide to approve the other PR for now, so it will not crash the system and keep this PR to see if we can find a better approach.