### PR TITLE
enhancement(transformer): Instantiate Date if mocked

### DIFF
--- a/src/transformer/descriptor/tsLibs/typecriptLibs.ts
+++ b/src/transformer/descriptor/tsLibs/typecriptLibs.ts
@@ -46,6 +46,8 @@ export function GetTypescriptTypeDescriptor(node: ts.TypeReferenceNode, scope: S
         [],
         [dataResolved],
       );
+    case(TypescriptLibsTypes.Date):
+      return ts.createNew(ts.createIdentifier('Date'), undefined, undefined);
     case(TypescriptLibsTypes.Map):
       return ts.createNew(ts.createIdentifier('Map'), undefined, undefined);
     case(TypescriptLibsTypes.Set):

--- a/src/transformer/descriptor/tsLibs/typescriptLibsTypes.ts
+++ b/src/transformer/descriptor/tsLibs/typescriptLibsTypes.ts
@@ -1,14 +1,15 @@
 export enum TypescriptLibsTypes {
   Array = 'Array',
-  ReadonlyArray = 'ReadonlyArray',
-  Number = 'Number',
-  String = 'String',
   Boolean = 'Boolean',
-  Object = 'Object',
+  Date = 'Date',
   Function = 'Function',
-  Promise = 'Promise',
   Map = 'Map',
-  Set = 'Set'
+  Number = 'Number',
+  Object = 'Object',
+  Promise = 'Promise',
+  ReadonlyArray = 'ReadonlyArray',
+  Set = 'Set',
+  String = 'String',
 }
 
 export const TypescriptLibsTypesFolder: string = 'node_modules/typescript/lib';

--- a/test/transformer/descriptor/tsLibs/tsLibs.test.ts
+++ b/test/transformer/descriptor/tsLibs/tsLibs.test.ts
@@ -66,13 +66,13 @@ describe('typescript lib', () => {
     expect(properties.a).toEqual([]);
   });
 
-  it('should set undefined for a Date', () => {
+  it('should create a new Date for a Date', () => {
     interface Interface {
       a: Date;
     }
 
     const properties: Interface = createMock<Interface>();
-    expect(properties.a).toBeUndefined();
+    expect(properties.a).toBeInstanceOf(Date);
   });
 
   it('should set a promise resolved for a promise', async () => {


### PR DESCRIPTION
This PR enables the use of Date for properties of mocked objects. It will simply instantiate a new instance of Date whenever the surrounding object is defined.