### PR TITLE
fix(release): create a release every time there are new changes on ma…

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -3,7 +3,7 @@ name: Performance
 on:
   push:
     branches:
-      - develop
+      - master
     paths:
       - 'src/**'
       - 'performance/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   release:
+    if: "startsWith(github.event.head_commit.message, 'ci(release): ts auto mock new version') != true"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,8 @@ name: Test
 on:
   push:
     branches:
-      - develop
       - master
   pull_request:
-    branches-ignore:
-      - master
 
 jobs:
   test:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -74,7 +74,7 @@
           "package-lock.json",
           "CHANGELOG.md"
         ],
-        "message": "ci(release): new version ${nextRelease.version}"
+        "message": "ci(release): ts auto mock new version ${nextRelease.version}"
       }
     ],
     [

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "if git-branch-is develop; then commitlint -E HUSKY_GIT_PARAMS; fi"
+      "commit-msg": "if git-branch-is master; then commitlint -E HUSKY_GIT_PARAMS; fi"
     }
   },
   "config": {


### PR DESCRIPTION
After few attempts on creating a release using a gitflow strategy I've realised that the process its confusing and there are a lot of things that could go wrong.
Keeping in sync master and develop its not an easy task, especially if you use a merge strategy that will result in a really confusing history.

I've decided that an automatic release on master branch its an okay solution for this project. If in the future we'll see too many releases an versions in npm we can find a better approach. 
