### PR TITLE
fix(enum): fix enum constant computed properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "test:features": "cross-env JASMINE_CONFIG=./test/features/jasmine.json TSCONFIG=./test/features/tsconfig.json npm run test:common",
         "test:logs": "cross-env JASMINE_CONFIG=./test/logs/jasmine.json TSCONFIG=./test/logs/tsconfig.json npm run test:common",
         "test:playground": "cross-env JASMINE_CONFIG=./test/playground/jasmine.json TSCONFIG=./test/playground/tsconfig.json npm run test:common",
+        "test:playground:build": "cross-env JASMINE_CONFIG=./test/playground/jasmine.build.json TSCONFIG=./test/playground/tsconfig.json npm run test:common",
         "test:common": "cross-var ts-node --files -r tsconfig-paths/register --compiler ttypescript --project $TSCONFIG node_modules/jasmine/bin/jasmine --config=$JASMINE_CONFIG",
         "dist:collect": "cp -r package.json package-lock.json README.md dist",
         "ts-check:src": "tsc --noEmit",

--- a/src/transformer/descriptor/enum/enumDeclaration.ts
+++ b/src/transformer/descriptor/enum/enumDeclaration.ts
@@ -7,19 +7,11 @@ export function GetEnumDeclarationDescriptor(
   node: ts.EnumDeclaration
 ): ts.Expression {
   const typeChecker: ts.TypeChecker = TypeChecker();
-  const typesList: ts.LiteralType[] = node.members.map((it: ts.EnumMember) =>
-    typeChecker.getTypeAtLocation(it)
-  ) as ts.LiteralType[];
 
   if (IsTsAutoMockRandomEnabled()) {
-    const nodesList: ts.Expression[] = typesList.map(
-      (type: ts.LiteralType, index: number) => {
-        if (type.hasOwnProperty('value')) {
-          return ts.createLiteral(type.value);
-        }
-
-        return ts.createLiteral(index);
-      }
+    const nodesList: ts.Expression[] = node.members.map(
+      (member: ts.EnumMember, index: number) =>
+        getEnumMemberValue(typeChecker, member, index)
     );
 
     return ts.createCall(
@@ -29,9 +21,13 @@ export function GetEnumDeclarationDescriptor(
     );
   }
 
-  if (typesList[0].hasOwnProperty('value')) {
-    return ts.createLiteral(typesList[0].value);
-  }
+  return getEnumMemberValue(typeChecker, node.members[0]);
+}
 
-  return ts.createLiteral(0);
+function getEnumMemberValue(
+  typeChecker: ts.TypeChecker,
+  member: ts.EnumMember,
+  defaultValue: string | number = 0
+): ts.Expression {
+  return ts.createLiteral(typeChecker.getConstantValue(member) || defaultValue);
 }

--- a/test/features/random/enum.test.ts
+++ b/test/features/random/enum.test.ts
@@ -96,15 +96,9 @@ describe('Random enum', () => {
     expect(thirdMock.direction).toBe(Direction.None);
   });
 
-  it('should have position of "computed" property, because transformer don\'t support computed Enum values', () => {
-    // Issue https://github.com/Typescript-TDD/ts-auto-mock/issues/339
-    function getComputed(): number {
-      return 12;
-    }
-
-    enum WithComputed {
-      Computed = getComputed(),
-      Computed2 = 1 + 4,
+  it('should get the correct const enum member computed property', () => {
+    const enum WithComputed {
+      Computed = 1 + 4,
     }
 
     interface IWithComputed {
@@ -116,11 +110,52 @@ describe('Random enum', () => {
     spy.and.returnValue(0);
     const mock1: IWithComputed = createMock<IWithComputed>();
 
-    expect(mock1.computed).toBe(0);
+    expect(mock1.computed).toBe(5);
+  });
+
+  it('should get the correct enum member computed property for constant expression', () => {
+    enum WithComputed {
+      Computed = 1 + 4,
+    }
+
+    interface IWithComputed {
+      computed: WithComputed;
+    }
+
+    const spy: jasmine.Spy = spyOn(Math, 'floor');
+
+    spy.and.returnValue(0);
+    const mock1: IWithComputed = createMock<IWithComputed>();
+
+    expect(mock1.computed).toBe(5);
+  });
+
+  it('should have position of non constant "computed" property, because transformer don\'t support non constant computed Enum values', () => {
+    // Issue https://github.com/Typescript-TDD/ts-auto-mock/issues/339
+    function getComputed(): number {
+      return 12;
+    }
+
+    enum WithComputed {
+      NonComputed,
+      Computed = getComputed(),
+      Computed1 = getComputed(),
+    }
+
+    interface IWithComputed {
+      computed: WithComputed;
+    }
+
+    const spy: jasmine.Spy = spyOn(Math, 'floor');
 
     spy.and.returnValue(1);
+    const mock1: IWithComputed = createMock<IWithComputed>();
+
+    expect(mock1.computed).toBe(1);
+
+    spy.and.returnValue(2);
     const mock2: IWithComputed = createMock<IWithComputed>();
 
-    expect(mock2.computed).toBe(1);
+    expect(mock2.computed).toBe(2);
   });
 });

--- a/test/playground/jasmine.build.json
+++ b/test/playground/jasmine.build.json
@@ -1,0 +1,5 @@
+{
+  "spec_dir": "./test/playground",
+  "spec_files": ["**/*test.js"],
+  "helpers": ["../reporter.js"]
+}

--- a/test/transformer/descriptor/enum.test.ts
+++ b/test/transformer/descriptor/enum.test.ts
@@ -38,3 +38,20 @@ describe('for enum from a module', () => {
     expect(properties.propertyWithDefaultValue).toEqual('1');
   });
 });
+
+describe('for enum with constant computed values', () => {
+  it('should assign the computed enum value of the first member', () => {
+    enum DirectionAssignNumber {
+      Right = 1 + 1,
+      Left = 1 + 5,
+    }
+
+    interface Interface {
+      a: DirectionAssignNumber;
+    }
+
+    const properties: Interface = createMock<Interface>();
+
+    expect(properties.a).toEqual(2);
+  });
+});


### PR DESCRIPTION
- Fixed case of constant enum computed member:
```ts
enum Constant {
  Value = 1 + 2
}
```
- added back npm script to run tests on the built version of playground, this will enable debugging the emitted code

Unfortunately non-constant enum computed members are still not fixed, to do that we have to find once and for all a way to import the enum in the file of the mock and use that directly.
Example of non-constant enum computed member:
```ts
function nonConstant(): number {
  return Math.Random();
}
enum Computed {
  Value = nonConstant()
}
```