### PR TITLE
fix(transformer): fix interface call signature with undeclared return type

### DIFF
--- a/definitelyTypedTests/src/processRunner.js
+++ b/definitelyTypedTests/src/processRunner.js
@@ -74,16 +74,14 @@ async function run(dir, processId) {
 
     try {
       const typeTsConfig = JSON.parse(typeTsConfigFileContent);
-
-      if (typeTsConfig && typeTsConfig.compilerOptions) {
-        if (typeTsConfig.compilerOptions.paths) {
-          config.compilerOptions.paths = typeTsConfig.compilerOptions.paths;
-        }
-
-        if (typeTsConfig.compilerOptions.lib) {
-          config.compilerOptions.lib = typeTsConfig.compilerOptions.lib;
-        }
-      }
+      copyTsConfigValues(typeTsConfig, config,
+        'paths',
+        'lib',
+        'types',
+        'esModuleInterop',
+        'target',
+        'module'
+      );
     } catch {
       console.warn('tsconfig.json of type found but failed to parse.');
     }
@@ -136,6 +134,16 @@ createDefinitelyTypedMock<typeof pak>();
         message: errorData,
       });
     });
+}
+
+function copyTsConfigValues(typeTsConfig, config, ...props) {
+  if (typeTsConfig && typeTsConfig.compilerOptions) {
+    props.forEach(prop => {
+      if (typeTsConfig.compilerOptions[prop]) {
+        config.compilerOptions[prop] = typeTsConfig.compilerOptions[prop];
+      }
+    });
+  }
 }
 
 module.exports = runProcesses;

--- a/src/transformer/descriptor/method/functionType.ts
+++ b/src/transformer/descriptor/method/functionType.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript';
 import { Scope } from '../../scope/scope';
 import { GetDescriptor } from '../descriptor';
 import { PropertySignatureCache } from '../property/cache';
+import { GetUndefinedDescriptor } from '../undefined/undefined';
 import { GetMethodDescriptor } from './method';
 
 export function GetFunctionTypeDescriptor(
@@ -13,11 +14,9 @@ export function GetFunctionTypeDescriptor(
 ): ts.Expression {
   const property: ts.PropertyName = PropertySignatureCache.instance.get();
 
-  if (!node.type) {
-    throw new Error(`No type was declared for ${node.getText()}.`);
-  }
-
-  const returnValue: ts.Expression = GetDescriptor(node.type, scope);
+  const returnValue: ts.Expression = node.type
+    ? GetDescriptor(node.type, scope)
+    : GetUndefinedDescriptor();
 
   return GetMethodDescriptor(property, returnValue);
 }

--- a/test/transformer/descriptor/methods/methods.test.ts
+++ b/test/transformer/descriptor/methods/methods.test.ts
@@ -100,6 +100,19 @@ describe('for methods', () => {
     });
   });
 
+  describe('for interface call signature with undeclared return value', () => {
+    interface InterfaceWithCallSignature {
+      (a: number);
+    }
+
+    it('should set the function with undefined return value', () => {
+      const properties: InterfaceWithCallSignature = createMock<
+        InterfaceWithCallSignature
+      >();
+      expect(properties(1)).toBeUndefined();
+    });
+  });
+
   describe('for interface construct signature', () => {
     interface InterfaceWithConstructSignature {
       new (a: number): { a: number };

--- a/ui/src/views/config.mdx
+++ b/ui/src/views/config.mdx
@@ -5,8 +5,6 @@ route: /config
 
 # Config
 ```ts
-tsAutoMockTransformer(program: ts.Program, options: TsAutoMockOptions)
-
 interface TsAutoMockOptions {
     debug: boolean | 'file' | 'console';
     cacheBetweenTests: boolean;
@@ -30,12 +28,16 @@ options:
 
 ---
 
+There are different ways to pass options to a transformer, every installation type has its own way, to know how to do it
+find your configuration in the [Installation page](./installation).
+
 ## Debug
 We currently support:
 - Logs for [not supported types](./types-not-supported)
 
 It will log any not supported type automatically converted to null.
 This is useful to report an issue or to investigate a potential bug.
+
 ---
 
 ## CacheBetweenTests

--- a/ui/src/views/installation.mdx
+++ b/ui/src/views/installation.mdx
@@ -16,6 +16,8 @@ There are different ways to do this depending on how you are currently compiling
 
 ## `jest` + `ts-jest` + `ttypescript`
 
+### Steps
+
 1. Install the dependencies
 
 ```
@@ -138,9 +140,23 @@ npm run test
 
 ... and you are all done!
 
+### Config options
+In the tsconfig.json you can add the config options next to the transformer name:
+```json
+"plugins": [
+  {
+    "transform": "ts-auto-mock/transformer",
+    "cacheBetweenTests": false,
+    "features": ["random"]
+  }
+]
+```
+
 ## Webpack
 
 With Webpack, You can use any TypeScript-related loader that supports custom transformers, e.g. `awesome-typescript-loader` or `ts-loader`:
+
+### Steps
 
 #### **`webpack.config.js`**
 ```js
@@ -166,8 +182,20 @@ module.exports = {
 };
 ```
 
+### Config options
+In webpack.config.js you can pass a second parameter to the transformer:
+```js
+before: [
+  tsAutoMockTransformer(program, {
+    features: ['random']
+  })
+]
+```
+
 ## ttypescript
 See [ttypescript's README](https://github.com/cevek/ttypescript/blob/master/README.md) for more information
+
+### Steps
 
 #### **`tsconfig.json`**
 ```json
@@ -182,9 +210,22 @@ See [ttypescript's README](https://github.com/cevek/ttypescript/blob/master/READ
 }
 ```
 
+### Config options
+In the tsconfig.json you can add the config options next to the transformer name:
+```json
+"plugins": [
+  {
+    "transform": "ts-auto-mock/transformer",
+    "cacheBetweenTests": false,
+    "features": ["random"]
+  }
+]
+```
 
 ## ts-patch
 See [ts-patch's README](https://github.com/nonara/ts-patch/blob/master/README.md)
+
+### Steps
 
 Command to run to install it:
 
@@ -207,10 +248,21 @@ tsconfig.json
 }
 ```
 
-## ts-node
+### Config options
+In the tsconfig.json you can add the config options next to the transformer name:
+```json
+"plugins": [
+  {
+    "transform": "ts-auto-mock/transformer",
+    "cacheBetweenTests": false,
+    "features": ["random"]
+  }
+]
+```
 
-### Mocha
+## ts-node + Mocha
 
+### Steps
 #### **`tsnode.js`**
 ```js
 const tsAutoMockTransformer = require('ts-auto-mock/transformer').default;
@@ -228,4 +280,14 @@ Then inject the registration with the `--require` flag that Mocha passes on to N
 
 ```
 mocha --require './tsnode.js' --watch-extensions ts,tsx "test/**/*.{ts,tsx}"
+```
+
+### Config options
+In tsnode.js you can pass a second parameter to the transformer:
+```js
+before: [
+  tsAutoMockTransformer(program, {
+    features: ['random']
+  })
+]
 ```


### PR DESCRIPTION
Also updated documentation to clarify where to add the transformer options and updated how we generate tsconfig for definitely typed test to reduce errors.