### PR TITLE
fix(createMockList): number of mocks on runtime

### DIFF
--- a/src/transformer/mergeExpression/mergeExpression.ts
+++ b/src/transformer/mergeExpression/mergeExpression.ts
@@ -3,7 +3,7 @@ import { MockDefiner } from '../mockDefiner/mockDefiner';
 import { ModuleName } from '../mockDefiner/modules/moduleName';
 import { PrivateIdentifier } from '../privateIdentifier/privateIdentifier';
 
-function mergePropertyAccessor(
+export function mergePropertyAccessor(
   methodName: string
 ): ts.PropertyAccessExpression {
   return ts.createPropertyAccess(
@@ -23,17 +23,5 @@ export function getMockMergeExpression(
     mergePropertyAccessor('merge'),
     [],
     [nodeMocked, defaultValues]
-  );
-}
-
-export function getMockMergeIteratorExpression(
-  nodeMocked: ts.Expression,
-  defaultValuesFunction: ts.Expression,
-  index: ts.NumericLiteral
-): ts.Expression {
-  return ts.createCall(
-    mergePropertyAccessor('mergeIterator'),
-    [],
-    [nodeMocked, defaultValuesFunction, index]
   );
 }

--- a/src/transformer/mock/mock.ts
+++ b/src/transformer/mock/mock.ts
@@ -1,14 +1,17 @@
 import * as ts from 'typescript';
 import { Logger } from '../../logger/logger';
-import { ArrayHelper } from '../array/array';
 import { GetDescriptor } from '../descriptor/descriptor';
 import { TypescriptHelper } from '../descriptor/helper/helper';
 import {
   getMockMergeExpression,
-  getMockMergeIteratorExpression,
+  mergePropertyAccessor,
 } from '../mergeExpression/mergeExpression';
 import { MockDefiner } from '../mockDefiner/mockDefiner';
 import { Scope } from '../scope/scope';
+import {
+  MockCreateMockListLoopArray,
+  MockCreateMockListLoopStep,
+} from '../mockIdentifier/mockIdentifier';
 import { SetCurrentCreateMock } from './currentCreateMockNode';
 
 function getMockExpression(nodeToMock: ts.TypeNode): ts.Expression {
@@ -21,34 +24,6 @@ function hasDefaultValues(node: ts.CallExpression): boolean {
 
 function hasDefaultListValues(node: ts.CallExpression): boolean {
   return !!node.arguments[1];
-}
-
-function getNumberFromNumericLiteral(
-  numericLiteral: ts.NumericLiteral
-): number {
-  const numericLiteralNumber: number = parseInt(numericLiteral.text, 10);
-  return numericLiteralNumber > 0 ? numericLiteralNumber : 0;
-}
-
-function getMockMergeListExpression(
-  mock: ts.Expression,
-  length: number,
-  defaultValues: ts.Expression
-): ts.Expression[] {
-  return ArrayHelper.ArrayFromLength(length).map((index: number) =>
-    getMockMergeIteratorExpression(
-      mock,
-      defaultValues,
-      ts.createNumericLiteral('' + index.toString())
-    )
-  );
-}
-
-function getMockListExpression(
-  mock: ts.Expression,
-  length: number
-): ts.Expression[] {
-  return ArrayHelper.ArrayFromLength(length).map(() => mock);
 }
 
 export function getMock(
@@ -69,7 +44,7 @@ export function getMock(
 export function getMockForList(
   nodeToMock: ts.TypeNode,
   node: ts.CallExpression
-): ts.ArrayLiteralExpression {
+): ts.Expression {
   SetCurrentCreateMock(node);
   const mock: ts.Expression = getMockExpression(nodeToMock);
   const lengthLiteral: ts.NumericLiteral = node
@@ -79,21 +54,93 @@ export function getMockForList(
     return ts.createArrayLiteral([]);
   }
 
-  const length: number = getNumberFromNumericLiteral(lengthLiteral);
-
   if (hasDefaultListValues(node)) {
-    const mockMergeList: ts.Expression[] = getMockMergeListExpression(
-      mock,
-      length,
-      node.arguments[1]
+    return getListCallMock(
+      node.arguments[0],
+      ts.createCall(
+        mergePropertyAccessor('mergeIterator'),
+        [],
+        [mock, node.arguments[1], MockCreateMockListLoopStep]
+      )
     );
-
-    return ts.createArrayLiteral(mockMergeList);
   }
 
-  const mockList: ts.Expression[] = getMockListExpression(mock, length);
+  return getListCallMock(node.arguments[0], mock);
+}
 
-  return ts.createArrayLiteral(mockList);
+function getListCallMock(
+  expression: ts.Expression,
+  mockExpr: ts.Expression
+): ts.CallExpression {
+  return ts.createCall(
+    ts.createParen(
+      ts.createFunctionExpression(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        ts.createBlock(
+          [
+            ts.createVariableStatement(
+              undefined,
+              ts.createVariableDeclarationList(
+                [
+                  ts.createVariableDeclaration(
+                    MockCreateMockListLoopArray,
+                    undefined,
+                    ts.createArrayLiteral([], false)
+                  ),
+                ],
+                ts.NodeFlags.Const
+              )
+            ),
+            ts.createFor(
+              ts.createVariableDeclarationList(
+                [
+                  ts.createVariableDeclaration(
+                    MockCreateMockListLoopStep,
+                    undefined,
+                    ts.createNumericLiteral('0')
+                  ),
+                ],
+                ts.NodeFlags.Let
+              ),
+              ts.createBinary(
+                MockCreateMockListLoopStep,
+                ts.createToken(ts.SyntaxKind.LessThanToken),
+                expression
+              ),
+              ts.createPostfix(
+                MockCreateMockListLoopStep,
+                ts.SyntaxKind.PlusPlusToken
+              ),
+              ts.createBlock(
+                [
+                  ts.createExpressionStatement(
+                    ts.createCall(
+                      ts.createPropertyAccess(
+                        MockCreateMockListLoopArray,
+                        ts.createIdentifier('push')
+                      ),
+                      undefined,
+                      [mockExpr]
+                    )
+                  ),
+                ],
+                true
+              )
+            ),
+            ts.createReturn(MockCreateMockListLoopArray),
+          ],
+          true
+        )
+      )
+    ),
+    undefined,
+    []
+  );
 }
 
 export function storeRegisterMock(

--- a/src/transformer/mockIdentifier/mockIdentifier.ts
+++ b/src/transformer/mockIdentifier/mockIdentifier.ts
@@ -21,3 +21,10 @@ export const MockIdentifierSetParameterName: ts.Identifier = ts.createIdentifier
 export const MockCallAnonymousText: string = '*';
 export const MockCallLiteralText: string = 'L';
 export const MockPrivatePrefix: string = 'ɵ';
+
+export const MockCreateMockListLoopStep: ts.Identifier = ts.createIdentifier(
+  'k'
+);
+export const MockCreateMockListLoopArray: ts.Identifier = ts.createIdentifier(
+  's'
+);

--- a/test/frameworkContext/create-mock-list-values.test.ts
+++ b/test/frameworkContext/create-mock-list-values.test.ts
@@ -30,4 +30,20 @@ describe('create-mock-list-values', () => {
     expect(properties[1].property.a).toBe(2);
     expect(properties[2].property.a).toBe(4);
   });
+
+  it('should create a list of mocks when the count of mocks is not literal', () => {
+    function two(): number {
+      return 2;
+    }
+
+    const mockList: Interface[] = createMockList<Interface>(
+      two(),
+      (index: number) => ({
+        property: {
+          a: index * 2,
+        },
+      })
+    );
+    expect(mockList.length).toBe(2);
+  });
 });

--- a/test/frameworkContext/create-mock-list.test.ts
+++ b/test/frameworkContext/create-mock-list.test.ts
@@ -1,4 +1,5 @@
 import { createMockList } from 'ts-auto-mock';
+import { getTwo } from './utils/function.test';
 
 describe('create-mock-list', () => {
   interface Interface {
@@ -11,5 +12,28 @@ describe('create-mock-list', () => {
     properties[0].method();
     expect(properties[0].method).toHaveBeenCalled();
     expect(properties[1].method).not.toHaveBeenCalled();
+  });
+
+  it('should create a list of mocks when the number is calculated from a function', () => {
+    function two(): number {
+      return 2;
+    }
+
+    const mockList: Interface[] = createMockList<Interface>(two());
+    expect(mockList.length).toBe(2);
+    expect(mockList[1].property).toBe('');
+  });
+
+  it('should create a list of mocks when the number is calculated from a function imported', () => {
+    const mockList: Interface[] = createMockList<Interface>(getTwo());
+    expect(mockList.length).toBe(2);
+    expect(mockList[1].property).toBe('');
+  });
+
+  it('should create a list of mocks when the number is in a variable', () => {
+    const numberOfMocks: number = 3;
+    const mockList: Interface[] = createMockList<Interface>(numberOfMocks);
+    expect(mockList.length).toBe(3);
+    expect(mockList[0].property).toBe('');
   });
 });

--- a/test/frameworkContext/utils/function.test.ts
+++ b/test/frameworkContext/utils/function.test.ts
@@ -1,0 +1,3 @@
+export function getTwo(): number {
+  return 2;
+}


### PR DESCRIPTION
Count the number of create mock list on runtime instead of relying on a numeric literal

I've also added a test to cover the merge default scenario

Simple scenario
```ts
interface A {
    a: string;
}
const getNumber: () => number = () => 2;
const type: A[] = createMockList<A>(getNumber());
```
generated code 
```js
  var type = (function() {
    var s = [];
    for (var k = 0; k < getNumber(); k++) {
      s.push(ɵRepository.ɵRepository.instance.getFactory('@A_1')([]));
    }
    return s;
  })();
```

With default values
```ts
interface A {
    a: string;
}

const type: A[] = createMockList<A>(getNumber(), (index: number) => ({
    a: index.toString()
}));
```

generated code

```js
  var type = (function() {
    var s = [];
    for (var k = 0; k < getNumber(); k++) {
      s.push(ɵMerge.ɵMerge.mergeIterator(ɵRepository.ɵRepository.instance.getFactory('@A_1')([]), function(index) {
        return ({
          a: index.toString()
        });
      }, k));
    }
    return s;
  })();
```

