### PR TITLE
feat(registerMock): allow use of mocked generics parameters in register mock factory

### DIFF
--- a/src/register-mock.ts
+++ b/src/register-mock.ts
@@ -1,6 +1,6 @@
 import { NoTransformerError } from './errors/no-transformer.error';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function registerMock<T extends object>(factory: () => T): void {
+export function registerMock<T extends object>(factory: (...args) => T): void {
   throw new Error(NoTransformerError);
 }

--- a/test/registerMock/generics/generics.test.ts
+++ b/test/registerMock/generics/generics.test.ts
@@ -1,0 +1,55 @@
+import { createMock, registerMock } from 'ts-auto-mock';
+
+describe('registerMock of type with generics', () => {
+  it('should provide mocked version of generics as parameters', () => {
+    type GenericsType<T> = {
+      internalProp: T;
+    };
+
+    type GenericsInterface<T, K> = {
+      internalProp: T;
+      internalProp2: K;
+    };
+
+    type GenericsInterface2<T, K> = {
+      internalProp: T;
+      internalProp2: K;
+    };
+
+    interface AParentInterface {
+      prop: GenericsType<string>;
+      prop2: GenericsInterface<number, 'Test'>;
+      prop3: GenericsInterface2<string, GenericsType<string>>;
+    }
+
+    registerMock<GenericsType<unknown>>((generic: unknown) => ({
+      internalProp: (generic as object).toString() + '-mocked',
+    }));
+
+    registerMock<GenericsInterface<unknown, unknown>>(
+      (genericNumber: unknown, genericString: unknown) => ({
+        internalProp: (genericNumber as number) + 5,
+        internalProp2: (genericString as object).toString() + '-mocked',
+      })
+    );
+
+    registerMock<GenericsInterface2<unknown, unknown>>(
+      (genericString: unknown, genericObject: unknown) => {
+        (genericObject as GenericsType<string>).internalProp += '-mocked';
+        return {
+          internalProp: (genericString as object).toString() + '-mocked',
+          internalProp2: genericObject,
+        };
+      }
+    );
+    const mock: AParentInterface = createMock<AParentInterface>();
+
+    expect(mock.prop.internalProp).toBe('-mocked');
+    expect(mock.prop2.internalProp).toBe(5);
+    expect(mock.prop2.internalProp2).toBe('Test-mocked');
+    expect(mock.prop3.internalProp).toBe('-mocked');
+    expect(mock.prop3.internalProp2).toEqual({
+      internalProp: '-mocked-mocked',
+    });
+  });
+});


### PR DESCRIPTION
To solve #604 now situations like Opaque type can be solved with this feature.

Example:
```ts
type Opaque<K, T> = T & { type: K };
registerMock<Opaque<unknown, unknown>>(
  (_type: unknown, valueMocked: unknown) => valueMocked as Opaque<unknown, unknown>
);

var mock = createMock<Opaque<'Test', string>>();
expect(mock).toBe('');

var mock2 = createMock<Opaque<'Test2', number>>();
expect(mock2).toBe(0);
```