### PR TITLE
fix(typeReference): log warning when type definition does not exists and cannot be located

### DIFF
--- a/config/utils/devtool.js
+++ b/config/utils/devtool.js
@@ -3,6 +3,6 @@ const ProcessService = require('../../utils/process/process');
 function DetermineDevToolFromDebugEnvironment() {
     const processService = ProcessService(process);
     const debug = processService.getEnvironmentValue('DEBUG');
-    return debug ? "cheap-module-eval-source-map": undefined;
+    return debug ? "eval-cheap-module-source-map": undefined;
 }
 module.exports = DetermineDevToolFromDebugEnvironment;

--- a/src/transformer/descriptor/typeReference/typeReference.ts
+++ b/src/transformer/descriptor/typeReference/typeReference.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { TransformerLogger } from '../../logger/transformerLogger';
 import { MockDefiner } from '../../mockDefiner/mockDefiner';
 import {
   CreateMockFactory,
@@ -8,6 +9,7 @@ import { Scope } from '../../scope/scope';
 import { isTypeReferenceReusable } from '../../typeReferenceReusable/typeReferenceReusable';
 import { GetDescriptor } from '../descriptor';
 import { TypescriptHelper } from '../helper/helper';
+import { GetNullDescriptor } from '../null/null';
 import {
   GetTypescriptTypeDescriptor,
   IsTypescriptType,
@@ -20,6 +22,11 @@ export function GetTypeReferenceDescriptor(
   const declaration: ts.Declaration = TypescriptHelper.GetDeclarationFromNode(
     node.typeName
   );
+
+  if (!declaration) {
+    TransformerLogger().missingTypeDefinition(node);
+    return GetNullDescriptor();
+  }
 
   if (MockDefiner.instance.hasMockForDeclaration(declaration, scope)) {
     return GetMockFactoryCall(node, declaration, scope);

--- a/src/transformer/logger/transformerLogger.ts
+++ b/src/transformer/logger/transformerLogger.ts
@@ -16,6 +16,8 @@ export interface TransformerLogger {
 
   typeOfPropertyNotFound(node: ts.Node): void;
 
+  missingTypeDefinition(node: ts.Node): void;
+
   indexedAccessTypeFailed(
     propertyName: string,
     nodeText: string,
@@ -108,6 +110,17 @@ ${warningPositionLog(createMockFileUrl, currentNodeFileUrl)}`
 
       logger.warning(
         `IndexedAccessType transformation failed: cannot find property ${propertyName} of - ${nodeText}
+${warningPositionLog(createMockFileUrl, currentNodeFileUrl)}`
+      );
+    },
+    missingTypeDefinition(node: ts.Node): void {
+      const createMockNode: ts.Node = GetCurrentCreateMock();
+
+      const createMockFileUrl: string = getNodeFileUrl(createMockNode);
+      const currentNodeFileUrl: string = getNodeFileUrl(node);
+
+      logger.warning(
+        `Type definition for type reference ${node.getText()} not found - it will convert to null
 ${warningPositionLog(createMockFileUrl, currentNodeFileUrl)}`
       );
     },

--- a/test/logs/missingTypeDefinition/missingTypeDefinition.warning.test.ts
+++ b/test/logs/missingTypeDefinition/missingTypeDefinition.warning.test.ts
@@ -1,0 +1,24 @@
+import { createMock } from 'ts-auto-mock';
+import { getLogsByCreateMockFileName, UnsupportedTypeLog } from '../utils/log';
+import { WrapperOfNotExistingType } from './missingTypeDefinition.warning.type';
+
+describe('Missing type definition', () => {
+  it('should log a warning and apply null', async () => {
+    const logs: UnsupportedTypeLog[] = await getLogsByCreateMockFileName(
+      'missingTypeDefinition.warning.test.ts'
+    );
+
+    createMock<WrapperOfNotExistingType>();
+    expect(logs.length).toBe(1);
+
+    expect(logs[0].header).toContain(
+      'WARNING: Transformer - Type definition for type reference NotExistingType not found - it will convert to null'
+    );
+    expect(logs[0].created).toMatch(
+      /created file:\/\/.*missingTypeDefinition\.warning\.test\.ts:[0-9]*:[0-9]*/
+    );
+    expect(logs[0].usedBy).toMatch(
+      /used by file:\/\/.*missingTypeDefinition\.warning\.type\.ts:[0-9]*:[0-9]*/
+    );
+  });
+});

--- a/test/logs/missingTypeDefinition/missingTypeDefinition.warning.type.ts
+++ b/test/logs/missingTypeDefinition/missingTypeDefinition.warning.type.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { NotExistingType } from 'aModule';
+
+export type WrapperOfNotExistingType = NotExistingType;


### PR DESCRIPTION
Thank you for your contribution to ts auto mock repo. 
Before submitting this PR, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] You have added tests


Prevent failure when a type cannot be located. This can happen if the developer put a ts-ignore when importing from JS libraries with no typings defined.

Also fixed webpack configuration to be able to build in debug mode.