### PR TITLE
refactor(transformer): make creation of mock configurable and shift responsibility to custom functions to identify configuration

### DIFF
--- a/definitelyTypedTests/src/transformer/customFunctions/create-definitely-typed-mock.ts
+++ b/definitelyTypedTests/src/transformer/customFunctions/create-definitely-typed-mock.ts
@@ -1,0 +1,82 @@
+import path from 'path';
+import * as ts from 'typescript';
+import { customFunctionWithTypeArgument } from '../../../../src/transformer/customFunctions/helpers/custom-function-with-type-argument';
+import { GetMockPropertiesFromDeclarations } from '../../../../src/transformer/descriptor/mock/mockProperties';
+import { GetPropertiesFromSourceFileOrModuleDeclaration } from '../../../../src/transformer/descriptor/module/module';
+import { CustomFunction } from '../../../../src/transformer/matcher/matcher';
+import { SetCurrentCreateMock } from '../../../../src/transformer/mock/currentCreateMockNode';
+import { getMock } from '../../../../src/transformer/mock/mock';
+import { GetProgram } from '../../../../src/transformer/program/program';
+import { Scope } from '../../../../src/transformer/scope/scope';
+import { TypeChecker } from '../../../../src/transformer/typeChecker/typeChecker';
+import { DefinitelyTypedTransformerLogger } from '../logger';
+
+type CompatibleStatement = ts.InterfaceDeclaration | ts.FunctionDeclaration | ts.ClassDeclaration | ts.ModuleDeclaration;
+
+export const createDefinitelyTypedMockCustomFunction: CustomFunction = customFunctionWithTypeArgument(
+  'create-definitely-typed-mock.d.ts',
+  'createDefinitelyTypedMock',
+  (node: ts.CallExpression, nodeToMock: ts.TypeNode): ts.Node => {
+    if (ts.isTypeQueryNode(nodeToMock)) {
+      SetCurrentCreateMock(node);
+      const typeChecker: ts.TypeChecker = TypeChecker();
+      const typeQuerySymbol: ts.Symbol | undefined = typeChecker.getSymbolAtLocation(nodeToMock.exprName);
+
+      if (!typeQuerySymbol) {
+        return getMock(node, { nodeToMock });
+      }
+
+      const typeQuerySymbolDeclaration: ts.ImportEqualsDeclaration = typeQuerySymbol.declarations[0] as ts.ImportEqualsDeclaration;
+      const symbolAlias: ts.Symbol | undefined = typeChecker.getSymbolAtLocation(typeQuerySymbolDeclaration.name);
+
+      if (!symbolAlias) {
+        return getMock(node, { nodeToMock });
+      }
+
+      const symbol: ts.Symbol = typeChecker.getAliasedSymbol(symbolAlias);
+
+      if (!symbol.declarations) {
+        const moduleName: string =
+          ((typeQuerySymbolDeclaration.moduleReference as ts.ExternalModuleReference).expression as ts.StringLiteral).text;
+        const pathModule: string = path.resolve(moduleName);
+        const moduleWithoutExportsFile: ts.SourceFile = GetProgram().getSourceFiles().find((file: ts.SourceFile) =>
+          path.relative(file.fileName, path.join(pathModule, 'index.d.ts')) === ''
+        ) as ts.SourceFile;
+
+        const compatibleStatements: ts.Statement[] = moduleWithoutExportsFile.statements.filter(
+          (statement: ts.Statement) => statement.kind === ts.SyntaxKind.InterfaceDeclaration
+            || statement.kind === ts.SyntaxKind.FunctionDeclaration
+            || statement.kind === ts.SyntaxKind.ClassDeclaration
+            || statement.kind === ts.SyntaxKind.ModuleDeclaration
+        );
+
+        if (compatibleStatements.length > 0) {
+          return ts.createArrayLiteral(compatibleStatements.map(
+            (workingStatement: CompatibleStatement) => {
+              const name: ts.Identifier = workingStatement.name as ts.Identifier;
+              const scope = new Scope();
+
+              if (ts.isModuleDeclaration(workingStatement)) {
+                return GetMockPropertiesFromDeclarations(
+                  GetPropertiesFromSourceFileOrModuleDeclaration((workingStatement as any).symbol, scope),
+                  [],
+                  scope
+                );
+              }
+
+              const nodeToMock: ts.TypeReferenceNode = ts.createTypeReferenceNode(name, undefined);
+              return getMock(node, { nodeToMock });
+
+            }, []));
+        }
+        DefinitelyTypedTransformerLogger().moduleWithoutValidTypeStatements(moduleName);
+
+        return node;
+      }
+
+      return getMock(node, { nodeToMock });
+    }
+    
+    return node;
+  }
+);

--- a/definitelyTypedTests/src/transformer/transformer.ts
+++ b/definitelyTypedTests/src/transformer/transformer.ts
@@ -1,96 +1,10 @@
-import { TypeChecker } from '../../../src/transformer/typeChecker/typeChecker';
-import { getMock } from '../../../src/transformer/mock/mock';
 import {
     CustomFunction
 } from "../../../src/transformer/matcher/matcher";
-import * as ts from 'typescript';
-import { GetProgram } from "../../../src/transformer/program/program";
 import { baseTransformer } from '../../../src/transformer/base/base';
-import { DefinitelyTypedTransformerLogger } from './logger';
-import * as path from 'path';
-import { GetPropertiesFromSourceFileOrModuleDeclaration } from '../../../src/transformer/descriptor/module/module';
-import { Scope } from '../../../src/transformer/scope/scope';
-import { GetMockPropertiesFromDeclarations } from '../../../src/transformer/descriptor/mock/mockProperties';
-import { SetCurrentCreateMock } from '../../../src/transformer/mock/currentCreateMockNode';
+import { createDefinitelyTypedMockCustomFunction } from './customFunctions/create-definitely-typed-mock';
 
-const customFunctions: CustomFunction[] = [
-    {
-        sourceDts: 'create-definitely-typed-mock.d.ts',
-        sourceUrl: '../create-definitely-typed-mock.d.ts',
-    }
-];
+const customFunctions: CustomFunction[] = [createDefinitelyTypedMockCustomFunction];
 
-const transformer = baseTransformer(visitNode, customFunctions);
+const transformer = baseTransformer(customFunctions);
 export { transformer };
-
-type CompatibleStatement = ts.InterfaceDeclaration | ts.FunctionDeclaration | ts.ClassDeclaration | ts.ModuleDeclaration;
-
-function visitNode(node: ts.CallExpression & { typeArguments: ts.NodeArray<ts.TypeNode> }, declaration: ts.FunctionDeclaration): ts.Node {
-    const [nodeToMock]: ts.NodeArray<ts.TypeNode> = node.typeArguments;
-
-    if (isCreateDefinitelyTypedMock(declaration) && ts.isTypeQueryNode(nodeToMock)) {
-        SetCurrentCreateMock(node);
-        const typeChecker: ts.TypeChecker = TypeChecker();
-        const typeQuerySymbol: ts.Symbol | undefined = typeChecker.getSymbolAtLocation(nodeToMock.exprName);
-
-        if (!typeQuerySymbol) {
-            return getMock(nodeToMock, node);
-        }
-
-        const typeQuerySymbolDeclaration: ts.ImportEqualsDeclaration = typeQuerySymbol.declarations[0] as ts.ImportEqualsDeclaration;
-        const symbolAlias: ts.Symbol | undefined = typeChecker.getSymbolAtLocation(typeQuerySymbolDeclaration.name);
-
-        if (!symbolAlias) {
-            return getMock(nodeToMock, node);
-        }
-
-        const symbol: ts.Symbol = typeChecker.getAliasedSymbol(symbolAlias);
-
-        if (!symbol.declarations) {
-            const moduleName: string =
-                ((typeQuerySymbolDeclaration.moduleReference as ts.ExternalModuleReference).expression as ts.StringLiteral).text;
-            const pathModule: string = path.resolve(moduleName);
-            const moduleWithoutExportsFile: ts.SourceFile = GetProgram().getSourceFiles().find((file: ts.SourceFile) =>
-                path.relative(file.fileName, path.join(pathModule, 'index.d.ts')) === ''
-            ) as ts.SourceFile;
-
-            const compatibleStatements: ts.Statement[] = moduleWithoutExportsFile.statements.filter(
-                (statement: ts.Statement) => statement.kind === ts.SyntaxKind.InterfaceDeclaration
-                    || statement.kind === ts.SyntaxKind.FunctionDeclaration
-                    || statement.kind === ts.SyntaxKind.ClassDeclaration
-                    || statement.kind === ts.SyntaxKind.ModuleDeclaration
-            );
-
-            if (compatibleStatements.length > 0) {
-                return ts.createArrayLiteral(compatibleStatements.map(
-                    (workingStatement: CompatibleStatement) => {
-                    const name: ts.Identifier = workingStatement.name as ts.Identifier;
-                    const scope = new Scope();
-
-                    if (ts.isModuleDeclaration(workingStatement)) {
-                        return GetMockPropertiesFromDeclarations(
-                            GetPropertiesFromSourceFileOrModuleDeclaration((workingStatement as any).symbol, scope),
-                            [],
-                            scope
-                        );
-                    }
-
-                    const nodeToMock: ts.TypeReferenceNode = ts.createTypeReferenceNode(name, undefined);
-                    return getMock(nodeToMock, node);
-
-                }, []));
-            }
-            DefinitelyTypedTransformerLogger().moduleWithoutValidTypeStatements(moduleName);
-
-            return node;
-        }
-
-        return getMock(nodeToMock, node);
-    }
-
-    return node;
-}
-
-function isCreateDefinitelyTypedMock(declaration: ts.FunctionDeclaration): boolean {
-    return !!declaration.name && declaration.name.getText() === 'createDefinitelyTypedMock';
-}

--- a/src/transformer/base/base.ts
+++ b/src/transformer/base/base.ts
@@ -4,17 +4,11 @@ import { SetTypeChecker } from '../typeChecker/typeChecker';
 import { MockDefiner } from '../mockDefiner/mockDefiner';
 import { SetProgram } from '../program/program';
 import { TypescriptHelper } from '../descriptor/helper/helper';
-import { CustomFunction, isFunctionFromThisLibrary } from '../matcher/matcher';
+import { CustomFunction, getMatchingCustomFunction } from '../matcher/matcher';
 import { GetIsFilesExcludedFromOptions } from '../../options/files';
 import { updateSourceFileNode } from '../../typescriptFactory/typescriptFactory';
 
-export type Visitor = (
-  node: ts.CallExpression & { typeArguments: ts.NodeArray<ts.TypeNode> },
-  declaration: ts.FunctionDeclaration
-) => ts.Node;
-
 export function baseTransformer(
-  visitor: Visitor,
   customFunctions: CustomFunction[]
 ): (
   program: ts.Program,
@@ -48,7 +42,6 @@ export function baseTransformer(
       let sourceFile: ts.SourceFile = visitNodeAndChildren(
         file,
         context,
-        visitor,
         customFunctions
       );
 
@@ -65,41 +58,27 @@ export function baseTransformer(
 function visitNodeAndChildren(
   node: ts.SourceFile,
   context: ts.TransformationContext,
-  visitor: Visitor,
   customFunctions: CustomFunction[]
 ): ts.SourceFile;
 function visitNodeAndChildren(
   node: ts.Node,
   context: ts.TransformationContext,
-  visitor: Visitor,
   customFunctions: CustomFunction[]
 ): ts.Node;
 function visitNodeAndChildren(
   node: ts.Node,
   context: ts.TransformationContext,
-  visitor: Visitor,
   customFunctions: CustomFunction[]
 ): ts.Node {
   return ts.visitEachChild(
-    visitNode(node, visitor, customFunctions),
+    visitNode(node, customFunctions),
     (childNode: ts.Node) =>
-      visitNodeAndChildren(childNode, context, visitor, customFunctions),
+      visitNodeAndChildren(childNode, context, customFunctions),
     context
   );
 }
 
-function isObjectWithProperty<T extends {}, K extends keyof T>(
-  obj: T,
-  key: K
-): obj is T & Required<{ [key in K]: T[K] }> {
-  return typeof obj[key] !== 'undefined';
-}
-
-function visitNode(
-  node: ts.Node,
-  visitor: Visitor,
-  customFunctions: CustomFunction[]
-): ts.Node {
+function visitNode(node: ts.Node, customFunctions: CustomFunction[]): ts.Node {
   if (!ts.isCallExpression(node)) {
     return node;
   }
@@ -108,29 +87,22 @@ function visitNode(
     | ts.Signature
     | undefined = TypescriptHelper.getSignatureOfCallExpression(node);
 
-  if (!signature || !isFunctionFromThisLibrary(signature, customFunctions)) {
+  if (!signature || !signature.declaration) {
     return node;
   }
 
-  if (
-    !isObjectWithProperty(node, 'typeArguments') ||
-    !node.typeArguments?.length
-  ) {
-    const mockFunction: string = node.getText();
+  const matchingCustomFunction: CustomFunction | void = getMatchingCustomFunction(
+    node,
+    signature.declaration,
+    customFunctions
+  );
 
-    throw new Error(
-      `It seems you've called \`${mockFunction}' without specifying a type argument to mock. 
-      Please refer to the documentation on how to use \`${mockFunction}': 
-      https://github.com/Typescript-TDD/ts-auto-mock#quick-overview`
-    );
+  if (!matchingCustomFunction) {
+    return node;
   }
 
-  const [nodeToMock]: ts.NodeArray<ts.TypeNode> = node.typeArguments;
-
-  MockDefiner.instance.setFileNameFromNode(nodeToMock);
+  MockDefiner.instance.setFileNameFromNode(node);
   MockDefiner.instance.setTsAutoMockImportIdentifier();
 
-  const declaration: ts.FunctionDeclaration = signature.declaration as ts.FunctionDeclaration;
-
-  return visitor(node, declaration);
+  return matchingCustomFunction.run(node);
 }

--- a/src/transformer/customFunctions/create-hydrated-mock.ts
+++ b/src/transformer/customFunctions/create-hydrated-mock.ts
@@ -1,0 +1,19 @@
+import * as ts from 'typescript';
+import { CustomFunction } from '../matcher/matcher';
+import { getMock } from '../mock/mock';
+import { customFunctionWithTypeArgument } from './helpers/custom-function-with-type-argument';
+
+export const createHydratedMockCustomFunction: CustomFunction = customFunctionWithTypeArgument(
+  'create-hydrated-mock.d.ts',
+  'createHydratedMock',
+  (node: ts.CallExpression, nodeToMock: ts.TypeNode): ts.Node =>
+    getMock(node, {
+      nodeToMock,
+      hydrated: true,
+      defaultValues: getDefaultValues(node),
+    })
+);
+
+function getDefaultValues(node: ts.CallExpression): ts.Expression | undefined {
+  return !!node.arguments.length ? node.arguments[0] : undefined;
+}

--- a/src/transformer/customFunctions/create-mock-list.ts
+++ b/src/transformer/customFunctions/create-mock-list.ts
@@ -1,0 +1,27 @@
+import * as ts from 'typescript';
+import { createArrayLiteral } from '../../typescriptFactory/typescriptFactory';
+import { CustomFunction } from '../matcher/matcher';
+import { getMock } from '../mock/mock';
+import { customFunctionWithTypeArgument } from './helpers/custom-function-with-type-argument';
+
+export const createMockListCustomFunction: CustomFunction = customFunctionWithTypeArgument(
+  'create-mock-list.d.ts',
+  'createMockList',
+  (node: ts.CallExpression, nodeToMock: ts.TypeNode): ts.Node => {
+    const lengthExpression: ts.Expression = node.arguments[0];
+
+    if (!lengthExpression) {
+      return createArrayLiteral([]);
+    }
+
+    return getMock(node, {
+      nodeToMock,
+      amount: lengthExpression,
+      defaultValues: getDefaultValues(node),
+    });
+  }
+);
+
+function getDefaultValues(node: ts.CallExpression): ts.Expression | undefined {
+  return !!node.arguments.length ? node.arguments[1] : undefined;
+}

--- a/src/transformer/customFunctions/create-mock.ts
+++ b/src/transformer/customFunctions/create-mock.ts
@@ -1,0 +1,18 @@
+import * as ts from 'typescript';
+import { CustomFunction } from '../matcher/matcher';
+import { getMock } from '../mock/mock';
+import { customFunctionWithTypeArgument } from './helpers/custom-function-with-type-argument';
+
+export const createMockCustomFunction: CustomFunction = customFunctionWithTypeArgument(
+  'create-mock.d.ts',
+  'createMock',
+  (node: ts.CallExpression, nodeToMock: ts.TypeNode): ts.Node =>
+    getMock(node, {
+      nodeToMock,
+      defaultValues: getDefaultValues(node),
+    })
+);
+
+function getDefaultValues(node: ts.CallExpression): ts.Expression | undefined {
+  return !!node.arguments.length ? node.arguments[0] : undefined;
+}

--- a/src/transformer/customFunctions/helpers/assert-type-argument-presence.ts
+++ b/src/transformer/customFunctions/helpers/assert-type-argument-presence.ts
@@ -1,0 +1,18 @@
+import * as ts from 'typescript';
+import { TypescriptHelper } from '../../descriptor/helper/helper';
+
+export function assertTypeArgumentPresence(
+  node: ts.CallExpression
+): asserts node is ts.CallExpression & {
+  typeArguments: ts.NodeArray<ts.TypeNode>;
+} {
+  if (!TypescriptHelper.hasTypeArguments(node)) {
+    const mockFunction: string = node.getText();
+
+    throw new Error(
+      `It seems you've called \`${mockFunction}' without specifying a type argument to mock. 
+          Please refer to the documentation on how to use \`${mockFunction}': 
+          https://github.com/Typescript-TDD/ts-auto-mock#quick-overview`
+    );
+  }
+}

--- a/src/transformer/customFunctions/helpers/custom-function-with-type-argument.ts
+++ b/src/transformer/customFunctions/helpers/custom-function-with-type-argument.ts
@@ -1,0 +1,33 @@
+import * as ts from 'typescript';
+import { CustomFunction } from '../../matcher/matcher';
+import { assertTypeArgumentPresence } from './assert-type-argument-presence';
+
+function isDeclarationWithName(
+  declaration: ts.SignatureDeclaration,
+  declarationName: string
+): boolean {
+  return declaration.name?.getText() === declarationName;
+}
+
+export function customFunctionWithTypeArgument(
+  sourceName: string,
+  declarationName: string,
+  run: (node: ts.CallExpression, typeArgument: ts.TypeNode) => ts.Node
+): CustomFunction {
+  return {
+    sourceDts: sourceName,
+    sourceUrl: `../${sourceName}`,
+    isHandledFunction(
+      node: ts.CallExpression,
+      declaration: ts.SignatureDeclaration
+    ): boolean {
+      return isDeclarationWithName(declaration, declarationName);
+    },
+    run(node: ts.CallExpression): ts.Node {
+      assertTypeArgumentPresence(node);
+      const [nodeToMock]: ts.NodeArray<ts.TypeNode> = node.typeArguments;
+
+      return run(node, nodeToMock);
+    },
+  };
+}

--- a/src/transformer/customFunctions/register-mock.ts
+++ b/src/transformer/customFunctions/register-mock.ts
@@ -1,0 +1,11 @@
+import * as ts from 'typescript';
+import { CustomFunction } from '../matcher/matcher';
+import { storeRegisterMock } from '../mock/mock';
+import { customFunctionWithTypeArgument } from './helpers/custom-function-with-type-argument';
+
+export const registerMockCustomFunction: CustomFunction = customFunctionWithTypeArgument(
+  'register-mock.d.ts',
+  'registerMock',
+  (node: ts.CallExpression, nodeToMock: ts.TypeNode): ts.Node =>
+    storeRegisterMock(nodeToMock, node)
+);

--- a/src/transformer/descriptor/helper/helper.ts
+++ b/src/transformer/descriptor/helper/helper.ts
@@ -142,6 +142,12 @@ export namespace TypescriptHelper {
     return typeChecker.getResolvedSignature(node);
   }
 
+  export function hasTypeArguments(node: ts.CallExpression): boolean {
+    return (
+      typeof node.typeArguments !== 'undefined' && !!node.typeArguments.length
+    );
+  }
+
   function GetFirstValidDeclaration(
     declarations: ts.Declaration[]
   ): ts.Declaration {

--- a/src/transformer/matcher/matcher.ts
+++ b/src/transformer/matcher/matcher.ts
@@ -5,26 +5,35 @@ import { TransformerLogger } from '../logger/transformerLogger';
 export interface CustomFunction {
   sourceUrl: string;
   sourceDts: string;
+
+  isHandledFunction(
+    node: ts.CallExpression,
+    declaration: ts.SignatureDeclaration
+  ): boolean;
+  run(node: ts.CallExpression): ts.Node;
 }
 
-export function isFunctionFromThisLibrary(
-  signature: ts.Signature,
+function isHandledDeclarationType(
+  declaration: ts.Declaration
+): declaration is ts.FunctionDeclaration | ts.MethodSignature {
+  return (
+    declaration &&
+    (ts.isFunctionDeclaration(declaration) || ts.isMethodSignature(declaration))
+  );
+}
+
+export function getMatchingCustomFunction(
+  node: ts.CallExpression,
+  declaration: ts.Declaration,
   customFunctions: CustomFunction[]
-): boolean {
-  if (!isDeclarationDefined(signature)) {
-    return false;
+): CustomFunction | void {
+  if (!isHandledDeclarationType(declaration)) {
+    return;
   }
 
-  if (
-    !signature.declaration ||
-    !ts.isFunctionDeclaration(signature.declaration)
-  ) {
-    return false;
-  }
+  const fileName: string = declaration.getSourceFile().fileName;
 
-  const fileName: string = signature.declaration.getSourceFile().fileName;
-
-  return customFunctions.some((customFunction: CustomFunction) => {
+  return customFunctions.find((customFunction: CustomFunction) => {
     const functionUrl: string = path.join(__dirname, customFunction.sourceUrl);
     const isFileNameFunctionUrl: boolean =
       path.relative(fileName, functionUrl) === '';
@@ -32,10 +41,9 @@ export function isFunctionFromThisLibrary(
       TransformerLogger().unexpectedCreateMock(fileName, functionUrl);
     }
 
-    return isFileNameFunctionUrl;
+    return (
+      isFileNameFunctionUrl &&
+      customFunction.isHandledFunction(node, declaration)
+    );
   });
-}
-
-function isDeclarationDefined(signature: ts.Signature): boolean {
-  return signature && !!signature.declaration;
 }

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -1,80 +1,22 @@
 import * as ts from 'typescript';
 import { TsAutoMockOptions } from '../options/options';
+import { createHydratedMockCustomFunction } from './customFunctions/create-hydrated-mock';
+import { createMockCustomFunction } from './customFunctions/create-mock';
+import { createMockListCustomFunction } from './customFunctions/create-mock-list';
+import { registerMockCustomFunction } from './customFunctions/register-mock';
 import { CustomFunction } from './matcher/matcher';
-import {
-  getHydratedMock,
-  getMock,
-  getMockForList,
-  storeRegisterMock,
-} from './mock/mock';
 import { baseTransformer } from './base/base';
 
 const customFunctions: CustomFunction[] = [
-  {
-    sourceDts: 'create-mock.d.ts',
-    sourceUrl: '../create-mock.d.ts',
-  },
-  {
-    sourceDts: 'create-mock-list.d.ts',
-    sourceUrl: '../create-mock-list.d.ts',
-  },
-  {
-    sourceDts: 'register-mock.d.ts',
-    sourceUrl: '../register-mock.d.ts',
-  },
-  {
-    sourceDts: 'create-hydrated-mock.d.ts',
-    sourceUrl: '../create-hydrated-mock.d.ts',
-  },
+  createMockCustomFunction,
+  createMockListCustomFunction,
+  registerMockCustomFunction,
+  createHydratedMockCustomFunction,
 ];
 
 const transformer: (
   program: ts.Program,
   options?: TsAutoMockOptions
-) => ts.TransformerFactory<ts.SourceFile> = baseTransformer(
-  visitNode,
-  customFunctions
-);
+) => ts.TransformerFactory<ts.SourceFile> = baseTransformer(customFunctions);
 
 export { transformer };
-
-function visitNode(
-  node: ts.CallExpression & { typeArguments: ts.NodeArray<ts.TypeNode> },
-  declaration: ts.FunctionDeclaration
-): ts.Node {
-  const [nodeToMock]: ts.NodeArray<ts.TypeNode> = node.typeArguments;
-
-  if (isCreateMock(declaration)) {
-    return getMock(nodeToMock, node);
-  }
-
-  if (isCreateHydratedMock(declaration)) {
-    return getHydratedMock(nodeToMock, node);
-  }
-
-  if (isCreateMockList(declaration)) {
-    return getMockForList(nodeToMock, node);
-  }
-
-  if (isRegisterMock(declaration)) {
-    return storeRegisterMock(nodeToMock, node);
-  }
-
-  return node;
-}
-
-function isCreateMock(declaration: ts.FunctionDeclaration): boolean {
-  return declaration.name?.getText() === 'createMock';
-}
-
-function isCreateHydratedMock(declaration: ts.FunctionDeclaration): boolean {
-  return declaration.name?.getText() === 'createHydratedMock';
-}
-
-function isCreateMockList(declaration: ts.FunctionDeclaration): boolean {
-  return declaration.name?.getText() === 'createMockList';
-}
-
-function isRegisterMock(declaration: ts.FunctionDeclaration): boolean {
-  return declaration.name?.getText() === 'registerMock';
-}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2016",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2016",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
Moved responsibility to identify options to the custom functions, option interface used to change the created mock, this way it's easier to create new custom functions with different mix of options (for example the missing hydrated-list).

This is also a prerequisite for the builder feature and the depth limit feature