### PR TITLE
build(dependencies): upgrade to jasmine version 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@semantic-release/changelog": "^6.0.1",
                 "@semantic-release/git": "^10.0.1",
                 "@semantic-release/github": "^8.0.4",
-                "@types/jasmine": "^3.8.2",
+                "@types/jasmine": "^4.0.3",
                 "@types/lodash-es": "^4.17.6",
                 "@types/micromatch": "^4.0.2",
                 "@types/node": "^16.4.13",
@@ -39,7 +39,7 @@
                 "eslint-webpack-plugin": "^3.1.1",
                 "git-branch-is": "^4.0.0",
                 "husky": "^7.0.4",
-                "jasmine": "^3.8.0",
+                "jasmine": "^4.1.0",
                 "jasmine-spec-reporter": "^7.0.0",
                 "no-emit-webpack-plugin": "^4.0.1",
                 "prettier": "^2.6.2",
@@ -55,6 +55,10 @@
                 "webpack-cli": "^4.9.2",
                 "webpack-merge": "^5.8.0",
                 "webpack-node-externals": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.x.x",
+                "npm": ">=8.x.x"
             },
             "peerDependencies": {
                 "typescript": "^4.X.X"
@@ -1463,9 +1467,9 @@
             }
         },
         "node_modules/@types/jasmine": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.8.2.tgz",
-            "integrity": "sha512-u5h7dqzy2XpXTzhOzSNQUQpKGFvROF8ElNX9P/TJvsHnTg/JvsAseVsGWQAQQldqanYaM+5kwxW909BBFAUYsg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
+            "integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
             "dev": true
         },
         "node_modules/@types/json-schema": {
@@ -7149,22 +7153,22 @@
             }
         },
         "node_modules/jasmine": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.8.0.tgz",
-            "integrity": "sha512-kdQ3SfcNpMbbMdgJPLyFe9IksixdnrgYaCJapP9sS0aLgdWdIZADNXEr+11Zafxm1VDfRSC5ZL4fzXT0bexzXw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.1.0.tgz",
+            "integrity": "sha512-4VhjbUgwfNS9CBnUMoSWr9tdNgOoOhNIjAD8YRxTn+PmOf4qTSC0Uqhk66dWGnz2vJxtNIU0uBjiwnsp4Ud9VA==",
             "dev": true,
             "dependencies": {
                 "glob": "^7.1.6",
-                "jasmine-core": "~3.8.0"
+                "jasmine-core": "^4.1.0"
             },
             "bin": {
                 "jasmine": "bin/jasmine.js"
             }
         },
         "node_modules/jasmine-core": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.8.0.tgz",
-            "integrity": "sha512-zl0nZWDrmbCiKns0NcjkFGYkVTGCPUgoHypTaj+G2AzaWus7QGoXARSlYsSle2VRpSdfJmM+hzmFKzQNhF2kHg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.1.0.tgz",
+            "integrity": "sha512-8E8BiffCL8sBwK1zU9cbavLe8xpJAgOduSJ6N8PJVv8VosQ/nxVTuXj2kUeHxTlZBVvh24G19ga7xdiaxlceKg==",
             "dev": true
         },
         "node_modules/jasmine-spec-reporter": {
@@ -14711,9 +14715,9 @@
             }
         },
         "@types/jasmine": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.8.2.tgz",
-            "integrity": "sha512-u5h7dqzy2XpXTzhOzSNQUQpKGFvROF8ElNX9P/TJvsHnTg/JvsAseVsGWQAQQldqanYaM+5kwxW909BBFAUYsg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
+            "integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
             "dev": true
         },
         "@types/json-schema": {
@@ -19215,13 +19219,13 @@
             }
         },
         "jasmine": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.8.0.tgz",
-            "integrity": "sha512-kdQ3SfcNpMbbMdgJPLyFe9IksixdnrgYaCJapP9sS0aLgdWdIZADNXEr+11Zafxm1VDfRSC5ZL4fzXT0bexzXw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.1.0.tgz",
+            "integrity": "sha512-4VhjbUgwfNS9CBnUMoSWr9tdNgOoOhNIjAD8YRxTn+PmOf4qTSC0Uqhk66dWGnz2vJxtNIU0uBjiwnsp4Ud9VA==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.6",
-                "jasmine-core": "~3.8.0"
+                "jasmine-core": "^4.1.0"
             },
             "dependencies": {
                 "glob": {
@@ -19241,9 +19245,9 @@
             }
         },
         "jasmine-core": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.8.0.tgz",
-            "integrity": "sha512-zl0nZWDrmbCiKns0NcjkFGYkVTGCPUgoHypTaj+G2AzaWus7QGoXARSlYsSle2VRpSdfJmM+hzmFKzQNhF2kHg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.1.0.tgz",
+            "integrity": "sha512-8E8BiffCL8sBwK1zU9cbavLe8xpJAgOduSJ6N8PJVv8VosQ/nxVTuXj2kUeHxTlZBVvh24G19ga7xdiaxlceKg==",
             "dev": true
         },
         "jasmine-spec-reporter": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^8.0.4",
-        "@types/jasmine": "^3.8.2",
+        "@types/jasmine": "^4.0.3",
         "@types/lodash-es": "^4.17.6",
         "@types/micromatch": "^4.0.2",
         "@types/node": "^16.4.13",
@@ -80,7 +80,7 @@
         "eslint-webpack-plugin": "^3.1.1",
         "git-branch-is": "^4.0.0",
         "husky": "^7.0.4",
-        "jasmine": "^3.8.0",
+        "jasmine": "^4.1.0",
         "jasmine-spec-reporter": "^7.0.0",
         "no-emit-webpack-plugin": "^4.0.1",
         "prettier": "^2.6.2",
@@ -113,8 +113,8 @@
             "config": "./commitizen.js"
         }
     },
-    "engines" : {
-        "npm" : ">=8.x.x",
-        "node" : ">=16.x.x"
+    "engines": {
+        "npm": ">=8.x.x",
+        "node": ">=16.x.x"
     }
 }

--- a/test/createHydratedMock/create-hydrated-mock.test.ts
+++ b/test/createHydratedMock/create-hydrated-mock.test.ts
@@ -1,4 +1,5 @@
 import { createHydratedMock, createMock, registerMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../transformer/utilities/getObjectKeyValues';
 
 describe('create-hydrated-mock', () => {
   describe('for not optional properties', () => {
@@ -217,12 +218,12 @@ describe('create-hydrated-mock', () => {
 
     it('should merge all the values', () => {
       const properties: Interface = createHydratedMock<Interface>();
-      expect(properties.intersection).toEqual({
+      expect(getObjectKeyValues(properties.intersection)).toEqual({
         a: '',
         b: 0,
       });
 
-      expect(properties.anotherIntersection).toEqual({
+      expect(getObjectKeyValues(properties.anotherIntersection)).toEqual({
         a: '',
         c: false,
       });

--- a/test/transformer/descriptor/assignments/assignments.test.ts
+++ b/test/transformer/descriptor/assignments/assignments.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('when assigned directly', () => {
   describe('return number', () => {
@@ -53,7 +54,7 @@ describe('when assigned directly', () => {
 
     it('should set the value', () => {
       const properties: MyClass = createMock<MyClass>();
-      expect(properties.value).toEqual({});
+      expect(getObjectKeyValues(properties.value)).toEqual({});
     });
   });
 
@@ -69,7 +70,7 @@ describe('when assigned directly', () => {
 
     it('should set the value', () => {
       const properties: MyClass = createMock<MyClass>();
-      expect(properties.value).toEqual({
+      expect(getObjectKeyValues(properties.value)).toEqual({
         a: 2,
         b: false,
         c: 'test',

--- a/test/transformer/descriptor/classes.test.ts
+++ b/test/transformer/descriptor/classes.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../utilities/getObjectKeyValues';
 import { AbstractClass } from './utils/classes/AbstractClass';
 import { Class } from './utils/classes/class';
 import { EmptyClass } from './utils/classes/EmptyClass';
@@ -26,7 +27,7 @@ describe('for classes', () => {
 
   it('should set an empty object for empty class', () => {
     const properties: EmptyClass = createMock<EmptyClass>();
-    expect(properties).toEqual({});
+    expect(getObjectKeyValues(properties)).toEqual({});
   });
 
   it('should set the correct properties for an abstract class', () => {

--- a/test/transformer/descriptor/dictionary.test.ts
+++ b/test/transformer/descriptor/dictionary.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../utilities/getObjectKeyValues';
 
 describe('for dictionary', () => {
   interface Test {
@@ -10,7 +11,7 @@ describe('for dictionary', () => {
 
   it('should set an empty object', () => {
     const properties: Dictionary<Test> = createMock<Dictionary<Test>>();
-    expect(properties).toEqual({});
+    expect(getObjectKeyValues(properties)).toEqual({});
   });
 
   describe('in a deep interface', () => {
@@ -23,7 +24,7 @@ describe('for dictionary', () => {
       const properties: InterfaceWithDictionary<Test> =
         createMock<InterfaceWithDictionary<Test>>();
       expect(properties.a).toBe('');
-      expect(properties.dictionary).toEqual({});
+      expect(getObjectKeyValues(properties.dictionary)).toEqual({});
     });
   });
 });

--- a/test/transformer/descriptor/extends.test.ts
+++ b/test/transformer/descriptor/extends.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../utilities/getObjectKeyValues';
 
 describe('for extends', () => {
   describe('for interface', () => {
@@ -66,7 +67,7 @@ describe('for extends', () => {
     it('should set the correct value', () => {
       const properties: Interface = createMock<Interface>();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(properties as any).toEqual({ a: 0 });
+      expect(getObjectKeyValues(properties) as any).toEqual({ a: 0 });
     });
   });
 
@@ -78,7 +79,7 @@ describe('for extends', () => {
     it('should ignore the typescript library', () => {
       const properties: Interface = createMock<Interface>();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(properties as any).toEqual({ a: 0 });
+      expect(getObjectKeyValues(properties) as any).toEqual({ a: 0 });
     });
   });
 
@@ -89,7 +90,7 @@ describe('for extends', () => {
     it('should ignore the typescript library', () => {
       const properties: Interface = createMock<Interface>();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(properties as any).toEqual({});
+      expect(getObjectKeyValues(properties) as any).toEqual({});
     });
   });
 });

--- a/test/transformer/descriptor/functions/functionsWithoutTypes.test.ts
+++ b/test/transformer/descriptor/functions/functionsWithoutTypes.test.ts
@@ -1,5 +1,6 @@
 import { createMock } from 'ts-auto-mock';
 import { anImportedObject } from '../utils/object/object';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('functions without types defined', () => {
   it('should infer basic boolean object literal types', () => {
@@ -46,7 +47,7 @@ describe('functions without types defined', () => {
     }
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type().primitiveValue).toEqual({
+    expect(getObjectKeyValues(type().primitiveValue)).toEqual({
       test: 'hello',
     });
   });
@@ -109,7 +110,7 @@ describe('functions without types defined', () => {
     }
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type()).toEqual({
+    expect(getObjectKeyValues(type())).toEqual({
       a: 'hello world',
       b: 123,
     });
@@ -124,7 +125,7 @@ describe('functions without types defined', () => {
     }
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type()).toEqual({
+    expect(getObjectKeyValues(type())).toEqual({
       a: 'hello world',
       b: 123,
     });
@@ -137,7 +138,7 @@ describe('functions without types defined', () => {
     }
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type()).toEqual({
+    expect(getObjectKeyValues(type())).toEqual({
       a: 'hello world',
       b: 123,
     });
@@ -152,7 +153,7 @@ describe('functions without types defined', () => {
     }
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type()).toEqual({
+    expect(getObjectKeyValues(type())).toEqual({
       a: 'hello world',
       b: 123,
     });
@@ -168,9 +169,11 @@ describe('functions without types defined', () => {
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
     expect(
-      type({
-        test: 'hello',
-      })
+      getObjectKeyValues(
+        type({
+          test: 'hello',
+        })
+      )
     ).toEqual({
       param: null,
     });
@@ -185,7 +188,7 @@ describe('functions without types defined', () => {
     }
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type('hello')).toEqual({
+    expect(getObjectKeyValues(type('hello'))).toEqual({
       param: '',
     });
   });
@@ -290,7 +293,7 @@ describe('arrow functions without types defined', () => {
     });
 
     const type: typeof functionToMock = createMock<typeof functionToMock>();
-    expect(type().sum('test1', 'test2')).toEqual({
+    expect(getObjectKeyValues(type().sum('test1', 'test2'))).toEqual({
       a: 'hello',
     });
   });

--- a/test/transformer/descriptor/generic/generic.test.ts
+++ b/test/transformer/descriptor/generic/generic.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('for generic', () => {
   describe('interface', () => {
@@ -149,12 +150,12 @@ describe('for generic', () => {
       const properties: GenericTwoValuesAndChildren<{
         a: string;
       }> = createMock<GenericTwoValuesAndChildren<{ a: string }>>();
-      expect(properties.generic1).toEqual({
+      expect(getObjectKeyValues(properties.generic1)).toEqual({
         a: '',
       });
       properties.generic1.a = 'change it';
       expect(properties.generic1.a).toBe('change it');
-      expect(properties.generic2.generic1).toEqual({
+      expect(getObjectKeyValues(properties.generic2.generic1)).toEqual({
         a: '',
       });
     });

--- a/test/transformer/descriptor/interface.test.ts
+++ b/test/transformer/descriptor/interface.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../utilities/getObjectKeyValues';
 
 describe('for interfaces', () => {
   describe('with multiple properties', () => {
@@ -21,7 +22,7 @@ describe('for interfaces', () => {
 
     it('should not fail', () => {
       const properties: Interface = createMock<Interface>();
-      expect(properties).toEqual({});
+      expect(getObjectKeyValues(properties)).toEqual({});
     });
   });
 

--- a/test/transformer/descriptor/intersection/intersection.test.ts
+++ b/test/transformer/descriptor/intersection/intersection.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('for intersection', () => {
   describe('different interfaces', () => {
@@ -18,12 +19,13 @@ describe('for intersection', () => {
 
     it('should merge all the values', () => {
       const properties: Interface = createMock<Interface>();
-      expect(properties.intersection).toEqual({
+
+      expect(getObjectKeyValues(properties.intersection)).toEqual({
         a: '',
         b: 0,
       });
 
-      expect(properties.anotherIntersection).toEqual({
+      expect(getObjectKeyValues(properties.anotherIntersection)).toEqual({
         a: '',
         c: false,
       });

--- a/test/transformer/descriptor/keyin/keyin.test.ts
+++ b/test/transformer/descriptor/keyin/keyin.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('for keyin', () => {
   describe('with an union', () => {
@@ -18,7 +19,7 @@ describe('for keyin', () => {
 
     it('should set an empty object', () => {
       const properties: MyType = createMock<MyType>();
-      expect(properties).toEqual({});
+      expect(getObjectKeyValues(properties)).toEqual({});
     });
   });
 

--- a/test/transformer/descriptor/literal/literal.test.ts
+++ b/test/transformer/descriptor/literal/literal.test.ts
@@ -9,6 +9,7 @@ import {
   TypeUnionTokenNumber,
   TypeUnionTokenSameBoolean,
 } from '../utils/types/typeUnion';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('for literal', () => {
   describe('with a specific string', () => {
@@ -95,7 +96,7 @@ describe('for literal', () => {
 
     it('should set the first one', () => {
       const properties: Interface = createMock<Interface>();
-      expect(properties.literal).toEqual({
+      expect(getObjectKeyValues(properties.literal)).toEqual({
         a: '',
       });
     });
@@ -119,7 +120,7 @@ describe('for literal', () => {
 
     it('should set the first one', () => {
       const properties: Interface = createMock<Interface>();
-      expect(properties.literal).toEqual({});
+      expect(getObjectKeyValues(properties.literal)).toEqual({});
     });
   });
 });

--- a/test/transformer/descriptor/tsLibs/tsLibs.test.ts
+++ b/test/transformer/descriptor/tsLibs/tsLibs.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from 'ts-auto-mock';
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 describe('typescript lib', () => {
   it('should set an empty array', () => {
@@ -39,7 +40,7 @@ describe('typescript lib', () => {
       a: object;
     }
     const properties: Interface = createMock<Interface>();
-    expect(properties.a).toEqual({});
+    expect(getObjectKeyValues(properties.a)).toEqual({});
   });
 
   it('should set the default value for an Object', () => {
@@ -47,7 +48,7 @@ describe('typescript lib', () => {
       a: Object;
     }
     const properties: Interface = createMock<Interface>();
-    expect(properties.a).toEqual({});
+    expect(getObjectKeyValues(properties.a)).toEqual({});
   });
 
   it('should set an empty function for a function', () => {
@@ -114,7 +115,7 @@ describe('typescript lib', () => {
     const interfaceCast: Interface = properties as unknown as Interface;
 
     const result: WithGenerics<string> = await interfaceCast.a();
-    expect(result).toEqual({
+    expect(getObjectKeyValues(result)).toEqual({
       generic: '',
     });
   });

--- a/test/transformer/descriptor/typeQuery/typeQuery.test.ts
+++ b/test/transformer/descriptor/typeQuery/typeQuery.test.ts
@@ -14,6 +14,7 @@ import {
 import REQUIRE_DEFAULT = require('../utils/interfaces/exportDefaultDeclaration');
 import REQUIRE_EQUAL = require('../utils/interfaces/exportEqualObject');
 import REQUIRE = require('../utils/typeQuery/typeQueryUtils');
+import { getObjectKeyValues } from '../../utilities/getObjectKeyValues';
 
 declare function functionDeclaration(): number;
 
@@ -78,7 +79,7 @@ describe('typeQuery', () => {
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      expect(functionMock()).toEqual({
+      expect(getObjectKeyValues(functionMock())).toEqual({
         b: '',
       });
     });

--- a/test/transformer/utilities/getObjectKeyValues.ts
+++ b/test/transformer/utilities/getObjectKeyValues.ts
@@ -1,0 +1,5 @@
+export const getObjectKeyValues: <T>(object: T) => T = <T>(object) =>
+  Object.getOwnPropertyNames(object).reduce((acc, property) => {
+    acc[property] = object[property];
+    return acc;
+  }, {} as T);


### PR DESCRIPTION
object equality now uses getOwnPropertyNames to find the keys of the mock. the deep comparison in jasmine version 3 was not considering symbols that are instead included in version 4
https://github.com/jasmine/jasmine/commit/8774562213f371f56a079523678c5141f03b47ec#diff-46cdc2a30e1879f73f5a62a709840911600e79ff44702785f1fafb4234789c57R5183
